### PR TITLE
Fix the logic around generating Loki configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,12 @@ Install the [charmcraft tool](https://juju.is/docs/sdk/setting-up-charmcraft) an
     charmcraft pack
 ```
 
+Deploy the charm with:
+
+```bash
+    juju deploy ./grafana-agent-k8s_ubuntu-20.04-amd64.charm --resource agent-image='grafana/agent:v0.20.1'
+```
+
 ## Code Overview
 
 The core implementation of this charm is represented by the [`GrafanaAgentOperatorCharm`](src/charm.py) class.

--- a/src/charm.py
+++ b/src/charm.py
@@ -161,7 +161,6 @@ class GrafanaAgentOperatorCharm(CharmBase):
                 logger.info("Successfully patched the Kubernetes service!")
 
     def _update_config(self, event=None):
-
         if not self._container.can_connect():
             # Pebble is not ready yet so no need to update config
             self.unit.status = WaitingStatus("waiting for agent container to start")
@@ -203,7 +202,11 @@ class GrafanaAgentOperatorCharm(CharmBase):
         config.update(self._server_config())
         config.update(self._integrations_config())
         config.update(self._prometheus_config())
-        config.update(self._loki_config(event))
+
+        # Don't accidentally destroy the Loki config by passing it
+        # `None` or `PebbleReady` or a `RelationEvent`
+        if isinstance(event, (LokiPushApiEndpointJoined, LokiPushApiEndpointDeparted)):
+            config.update(self._loki_config(event))
 
         return yaml.dump(config)
 


### PR DESCRIPTION
Previously, the `_loki_config()` method in the charm checked the type of the object passed in. If it was an event from the consumer that the relation was joined (which really means "has a consumer"), a Loki config was generated. If it was broken, it was removed.

However, the "default" case also generated an empty config, and the same object was blindly passed around without typechecking. A type assertion would easily have missed a `PebbleReadyEvent`, `None`, a `Relation*` event, or anything else which made it there, and generated an empty Loki config the first time anything happened to the charm which was _not_ a change to the logging relation.

Type check *before* we try to generate the Loki config stub.

Also, update the docs for which image is needed to make an easy deployment example.

Bring the `prometheus_scrape` library in line with the current release.