### PR TITLE
Loki config missing if VM running juju and microk8s is restarted or pod is deleted

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -168,6 +168,11 @@ class GrafanaAgentOperatorCharm(CharmBase):
                 self._container.restart(self._name)
                 self.unit.status = ActiveStatus()
         except APIError as e:
+            # When Juju creates a new unit (because the previous one was killed)
+            # the `_on_loki_push_api_endpoint_joined` event is fired before `pebble-ready` event,
+            # BUT when Pebble is actually ready (self._container.can_connect() is True).
+            # APIError is raised because "agent" service doesn't exist yet since we add that
+            # layer in on_pebble_ready.
             self.unit.status = WaitingStatus(str(e))
             event.defer()
         except GrafanaAgentReloadError as e:

--- a/src/charm.py
+++ b/src/charm.py
@@ -149,7 +149,6 @@ class GrafanaAgentOperatorCharm(CharmBase):
         if not self._container.can_connect():
             # Pebble is not ready yet so no need to update config
             self.unit.status = WaitingStatus("waiting for agent container to start")
-            event.defer()
             return
 
         config = self._config_file(event)


### PR DESCRIPTION
This PR fixes #34.

There are 2 way to test this PR:

#### Restart VM

- Deploy Loki and deploy 2 Grafana agents
- Relate both charms
- Check the grafana agent config file has the `loki` section
- **Stop the multipass VM** in which Juju and microk8s are running.
- Start the multipass VM again.
- Check that once microk8s is up and running again the grafana agent config has the `loki` section

#### Delete POD

- Deploy Loki and deploy 2 Grafana agents
- Relate both charms
- Check the grafana agent config file has the `loki` section
- **Delete** the grafana agent pod with: `microk8s.kubectl delete pods grafana-agent-k8s-0 -n observability`
- Wait until the pod is deleted and Juju creates a new unit to replace the deleted one.
- Check grafana agent config has the `loki` section