### PR TITLE
Fix grafana-agent version in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Install the [charmcraft tool](https://juju.is/docs/sdk/setting-up-charmcraft) an
 Deploy the charm with:
 
 ```bash
-    juju deploy ./grafana-agent-k8s_ubuntu-20.04-amd64.charm --resource agent-image='grafana/agent:v0.20.1'
+    juju deploy ./grafana-agent-k8s_ubuntu-20.04-amd64.charm --resource agent-image='grafana/agent:v0.26.1'
 ```
 
 ## Code Overview

--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ More detailed information about these relations can be found in [Charmhub docs p
 
 ## OCI Images
 
-This charm by default uses the `v0.20.1` release of the [grafana/agent](https://hub.docker.com/r/grafana/agent)
+This charm by default uses the `v0.26.1` release of the [grafana/agent](https://hub.docker.com/r/grafana/agent)


### PR DESCRIPTION
## Issue
The indicated version of the used **grafana-agent** is outdated compared to the one used in the latest revision.

## Solution
Updating the files where `v0.20.1` appears, correcting it to `v0.26.1`.

## Release Notes
Updating the **grafana-agent** version in the documentation to the version used in the latest revision.
