### PR TITLE
assume k8s api is available

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,9 +7,11 @@ description: |
   Grafana Agent for Kubernetes cluster
 summary: |
   Grafana Agent is a telemetry collector for sending metrics, logs, and trace data to the opinionated Grafana observability stack.
-
 maintainers:
     - Jose Massón <jose.masson@canonical.com>
+
+assumes:
+  - k8s-api
 
 docs: https://discourse.charmhub.io/t/grafana-agent-k8s-docs-index/5605
 website: https://charmhub.io/grafana-agent-k8s


### PR DESCRIPTION
To prevent people from mistakenly trying to deploy this charm on lxd or similar, add an assumption about the k8s-api being available.