### PR TITLE
Machine charm bugfixes that enable the charm to run without errors. T…

### DIFF
--- a/machine_metadata.yaml
+++ b/machine_metadata.yaml
@@ -15,7 +15,7 @@ website: https://charmhub.io/grafana-agent
 source: https://github.com/canonical/grafana-agent-k8s-operator
 issues: https://github.com/canonical/grafana-agent-k8s-operator/issues
 
-series: []
+series: [jammy, focal]
 subordinate: true
 
 requires:

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -402,7 +402,7 @@ class GrafanaAgentCharm(CharmBase):
                 }
             )
 
-        if self.is_machine:
+        if self.is_machine():
             logs_config["logs"]["configs"].append(
                 {
                     "name": "log_file_scraper",
@@ -414,13 +414,16 @@ class GrafanaAgentCharm(CharmBase):
                                 "labels": {
                                     "__path__": "/var/log/*",
                                     "__path_exclude__": "/var/log/positions.yaml",
-                                }.update(self.get_principal_labels())
+                                    **self.get_principal_labels(),
+                                }
                             },
                         },
                         {"job_name": "syslog", "journal": {"labels": self.get_principal_labels()}},
                     ],
                 }
             )
+            
+        return logs_config
 
     def _reload_config(self, attempts: int = 10) -> None:
         """Reload the config file.

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -102,6 +102,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         """Restart grafana agent."""
         self._container.restart("agent")
 
+    @property
     def is_machine(self) -> bool:
         """Check if this is a machine charm."""
         return False

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -68,6 +68,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
             )
         self._update_status()
 
+    @property
     def is_ready(self):
         """Checks if the charm is ready for configuration."""
         return self._container.can_connect()

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -12,7 +12,14 @@ import urllib
 from typing import Dict, Optional, Union
 
 from ops.main import main
-from ops.model import Relation, Unit
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    Relation,
+    Unit,
+    WaitingStatus,
+)
 
 from grafana_agent import GrafanaAgentCharm
 
@@ -51,7 +58,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     def on_install(self, _) -> None:
         """Install the Grafana Agent snap."""
         # Check if Grafana Agent is installed
-        if not self._is_installed():
+        if not self._is_installed:
             # We need to download the snap from github and install with --dangerous.
             # This should be changed once grafana-agent is in the snap store.
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -65,7 +72,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
                         ).read()
                     )
                 subprocess.run(["sudo", "snap", "install", "--dangerous", "--devmode", snap_file])
-            if not self._is_installed():
+            if not self._is_installed:
                 raise GrafanaAgentInstallError("Failed to install grafana-agent.")
             connect_process = subprocess.run(
                 ["sudo", "snap", "connect", "grafana-agent:etc-grafana-agent"]
@@ -75,9 +82,13 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
 
     def on_start(self, _) -> None:
         """Start Grafana Agent."""
+        # Ensure the config is up to date before we start to avoid racy relation changes and starting
+        # with a "bare" config in ActiveStatus
+        self._update_config(None)
         start_process = subprocess.run(["sudo", "snap", "start", "--enable", self._service])
         if start_process.returncode != 0:
             raise GrafanaAgentServiceError("Failed to start grafana-agent")
+        self.unit.status = ActiveStatus()
 
     def on_stop(self, _) -> None:
         """Stop Grafana Agent."""
@@ -88,12 +99,13 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     def on_remove(self, _) -> None:
         """Uninstall the Grafana Agent snap."""
         subprocess.run(["sudo", "snap", "remove", "--purge", "grafana-agent"])
-        if self._is_installed():
+        if self._is_installed:
             raise GrafanaAgentInstallError("Failed to uninstall grafana-agent")
 
+    @property
     def is_ready(self):
         """Checks if the charm is ready for configuration."""
-        return self._is_installed() and self.principal_unit
+        return self._is_installed and self.principal_unit
 
     def agent_version_output(self) -> str:
         """Runs `agent -version` and returns the output.
@@ -131,6 +143,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         """Check if this is a machine charm."""
         return True
 
+    @property
     def _is_installed(self) -> bool:
         """Check if the Grafana Agent snap is installed."""
         package_check = subprocess.run("snap list | grep grafana-agent", shell=True)
@@ -190,7 +203,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         }
 
     @property
-    def _principal_relabels(self) -> list:
+    def _principal_relabeling_config(self) -> list:
         """Return a relabel config with labels from the topology of the principal charm."""
         topology_relabels = [
             {


### PR DESCRIPTION
…he following were fixed.

1. Due to the ordering of life cycle events, we have to wait until the relation_joined event of the juju-info relation before we try to read the unit from the relation. The is_ready method is updated to reflect this.
2. The old method for fetching the unit changes the state of the charm instance. This is problematic because there are event handlers in the charm that perform this operation twice. A new property was added called principal_unit which fetches the unit in a safe but ugly manner.
3. There were a few instances of the dict.update method being used to merge dictionaries. The problem here is that dict.update updates dictionaries in place and does not return the new value. In these particular cases, dictionary unpacking is better.
4. A return value was added to GrafanaAgentCharm._loki_config.
5. Fixed some typos.

The grafana-agent itself still doesn't work because the configuration files produced aren't quite right.
