### PR TITLE
Class split

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -48,7 +48,7 @@ class GrafanaAgentCharm(CharmBase):
     """Grafana Agent Charm."""
 
     _name = "agent"
-    _promtail_positions = "/tmp/positions.yaml"
+    _promtail_positions = "/run/promtail-positions.yaml"
     _http_listen_port = 3500
     _grpc_listen_port = 3600
 
@@ -195,7 +195,11 @@ class GrafanaAgentCharm(CharmBase):
         self._update_status()
 
     def _update_status(self) -> bool:
-        """Update the status to reflect the status quo."""
+        """Update the status to reflect the status quo.
+
+        Returns:
+            True if the status was set to Active; False otherwise.
+        """
         if len(self.model.relations["metrics-endpoint"]):
             if not len(self.model.relations[REMOTE_WRITE_RELATION_NAME]):
                 self.unit.status = WaitingStatus("no related Prometheus remote-write")
@@ -226,6 +230,7 @@ class GrafanaAgentCharm(CharmBase):
 
         if config == old_config:
             # Nothing changed, possibly new install. Set us active and move on.
+            self.unit.status = ActiveStatus()
             return
 
         try:

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -8,7 +8,7 @@ import pathlib
 import re
 import shutil
 from collections import namedtuple
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import yaml
 from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer, LokiPushApiProvider
@@ -96,12 +96,10 @@ class GrafanaAgentCharm(CharmBase):
         )
 
         self.framework.observe(
-            self._loki_consumer.on.loki_push_api_endpoint_joined,
-            self._on_loki_push_api_endpoint_joined,
+            self._loki_consumer.on.loki_push_api_endpoint_joined, self._update_config
         )
         self.framework.observe(
-            self._loki_consumer.on.loki_push_api_endpoint_departed,
-            self._on_loki_push_api_endpoint_departed,
+            self._loki_consumer.on.loki_push_api_endpoint_departed, self._update_config
         )
         self.framework.observe(self.on.config_changed, self._update_config)
 
@@ -142,6 +140,16 @@ class GrafanaAgentCharm(CharmBase):
         """Check if this is a machine charm."""
         raise NotImplementedError("Please override the is_machine method")
 
+    @property
+    def _additional_integrations(self) -> Dict[str, Any]:
+        """Additional per-type integrations to inject."""
+        raise NotImplementedError("Please override the _additional_integrations method")
+
+    @property
+    def _additional_log_configs(self) -> List[Dict[str, Any]]:
+        """Additional per-type integrations to inject."""
+        raise NotImplementedError("Please override the _additional_log_configs method")
+
     # End: Abstract Methods
 
     def _metrics_alerts(self, event):
@@ -181,14 +189,6 @@ class GrafanaAgentCharm(CharmBase):
             logger.debug("updated alert rules file {}".format(file_handle.absolute()))
         reload_func()
 
-    def _on_loki_push_api_endpoint_joined(self, event) -> None:
-        """Event handler for the logging relation changed event."""
-        self._update_config(event)
-
-    def _on_loki_push_api_endpoint_departed(self, event) -> None:
-        """Event handler for the loki departed."""
-        self._update_config(event)
-
     def on_scrape_targets_changed(self, event) -> None:
         """Event handler for the scrape targets changed event."""
         self._update_config(event)
@@ -199,18 +199,19 @@ class GrafanaAgentCharm(CharmBase):
         self._update_config(event)
         self._update_status()
 
-    def _update_status(self) -> None:
+    def _update_status(self) -> bool:
         """Update the status to reflect the status quo."""
         if len(self.model.relations["metrics-endpoint"]):
             if not len(self.model.relations[REMOTE_WRITE_RELATION_NAME]):
                 self.unit.status = WaitingStatus("no related Prometheus remote-write")
-                return
+                return False
 
         if not self.is_ready:
             self.unit.status = WaitingStatus("waiting for the agent to start")
-            return
+            return False
 
         self.unit.status = ActiveStatus()
+        return True
 
     def _update_config(self, _) -> None:
         if not self.is_ready:
@@ -218,7 +219,7 @@ class GrafanaAgentCharm(CharmBase):
             self.unit.status = WaitingStatus("waiting for agent to start")
             return
 
-        config = self._config_file()
+        config = self._generate_config()
         old_config = None
 
         try:
@@ -252,119 +253,15 @@ class GrafanaAgentCharm(CharmBase):
         """
         return f"-config.file={CONFIG_PATH}"
 
-    def _config_file(self) -> Dict[str, Any]:
+    def _generate_config(self) -> Dict[str, Any]:
         """Generates config file str.
 
         Returns:
             A yaml string with grafana agent config
         """
-        config = {}
-        config.update(self._server_config())
-        config.update(self._integrations_config())
-        config.update(self._prometheus_config())
-        config.update(self._loki_config())
-        return config
-
-    def _server_config(self) -> dict:
-        """Return the server section of the config.
-
-        Returns:
-            The dict representing the config
-        """
-        return {"server": {"log_level": "info"}}
-
-    def _integrations_config(self) -> dict:
-        """Return the integrations section of the config.
-
-        Returns:
-            The dict representing the config
-        """
-        juju_model = self.model.name
-        juju_model_uuid = self.model.uuid
-        juju_application = self.model.app.name
-        juju_unit = self.unit.name
-
-        # Align the "job" name with those of prometheus_scrape
-        job_name = f"juju_{juju_model}_{juju_model_uuid}_{juju_application}_self-monitoring"
-        instance_value = f"{juju_model}_{juju_model_uuid}_{juju_application}_{juju_unit}"
-
-        relabel_configs = [
-            # Align the "instance" label with the rest of the Juju-collected metrics
-            {
-                "target_label": "instance",
-                "regex": "(.*)",
-                "replacement": instance_value,
-            },
-            {  # To add a label, we create a relabelling that replaces a built-in
-                "source_labels": ["__address__"],
-                "target_label": "juju_charm",
-                "replacement": self.meta.name,
-            },
-            {  # To add a label, we create a relabelling that replaces a built-in
-                "source_labels": ["__address__"],
-                "target_label": "juju_model",
-                "replacement": juju_model,
-            },
-            {
-                "source_labels": ["__address__"],
-                "target_label": "juju_model_uuid",
-                "replacement": juju_model_uuid,
-            },
-            {
-                "source_labels": ["__address__"],
-                "target_label": "juju_application",
-                "replacement": juju_application,
-            },
-            {
-                "source_labels": ["__address__"],
-                "target_label": "juju_unit",
-                "replacement": juju_unit,
-            },
-        ]
-
-        conf = {
-            "integrations": {
-                "agent": {
-                    "enabled": True,
-                    "relabel_configs": [
-                        {
-                            "target_label": "job",
-                            "regex": "(.*)",
-                            "replacement": job_name,
-                        },
-                    ]
-                    + relabel_configs,
-                },
-                "prometheus_remote_write": self._remote_write.endpoints,
-            }
-        }
-
-        if self.is_machine:
-            node_exporter_job_name = (
-                f"juju_{juju_model}_{juju_model_uuid}_{juju_application}_node-exporter"
-            )
-            conf["integrations"]["node_exporter"] = {
-                "enabled": True,
-                "relabel_configs": [
-                    # Align the "job" name with those of prometheus_scrape
-                    {
-                        "target_label": "job",
-                        "regex": "(.*)",
-                        "replacement": node_exporter_job_name,
-                    },
-                ]
-                + self._principal_relabeling_config,
-            }
-
-        return conf
-
-    def _prometheus_config(self) -> dict:
-        """Return the prometheus section of the config.
-
-        Returns:
-            The dict representing the config
-        """
-        return {
+        config = {
+            "server": {"log_level": "info"},
+            "integrations": self._integrations_config,
             "metrics": {
                 "wal_directory": "/tmp/agent/data",
                 "configs": [
@@ -374,10 +271,73 @@ class GrafanaAgentCharm(CharmBase):
                         "remote_write": self._remote_write.endpoints,
                     }
                 ],
-            }
+            },
+            "logs": self._loki_config,
         }
+        return config
 
-    def _loki_config(self) -> dict:
+    @property
+    def _integrations_config(self) -> dict:
+        """Return the integrations section of the config.
+
+        Returns:
+            The dict representing the config
+        """
+        juju_model = self.model.name
+        juju_model_uuid = self.model.uuid
+        juju_application = self.model.app.name
+
+        # Align the "job" name with those of prometheus_scrape
+        job_name = f"juju_{juju_model}_{juju_model_uuid}_{juju_application}_self-monitoring"
+
+        conf = {
+            "agent": {
+                "enabled": True,
+                "relabel_configs": [
+                    {
+                        "target_label": "job",
+                        "regex": "(.*)",
+                        "replacement": job_name,
+                    },
+                    {  # Align the "instance" label with the rest of the Juju-collected metrics
+                        "target_label": "instance",
+                        "regex": "(.*)",
+                        "replacement": self._instance_name,
+                    },
+                    {  # To add a label, we create a relabelling that replaces a built-in
+                        "source_labels": ["__address__"],
+                        "target_label": "juju_charm",
+                        "replacement": self.meta.name,
+                    },
+                    {  # To add a label, we create a relabelling that replaces a built-in
+                        "source_labels": ["__address__"],
+                        "target_label": "juju_model",
+                        "replacement": self.model.name,
+                    },
+                    {
+                        "source_labels": ["__address__"],
+                        "target_label": "juju_model_uuid",
+                        "replacement": self.model.uuid,
+                    },
+                    {
+                        "source_labels": ["__address__"],
+                        "target_label": "juju_application",
+                        "replacement": self.model.app.name,
+                    },
+                    {
+                        "source_labels": ["__address__"],
+                        "target_label": "juju_unit",
+                        "replacement": self.model.unit.name,
+                    },
+                ],
+            },
+            "prometheus_remote_write": self._remote_write.endpoints,
+            **self._additional_integrations,
+        }
+        return conf
+
+    @property
+    def _loki_config(self) -> Dict[str, List[Any]]:
         """Modifies the loki section of the config.
 
         Returns:
@@ -390,6 +350,7 @@ class GrafanaAgentCharm(CharmBase):
                 {
                     "name": "push_api_server",
                     "clients": self._loki_consumer.loki_endpoints,
+                    "positions": {"filename": "/tmp/positions.yaml"},
                     "scrape_configs": [
                         {
                             "job_name": "loki",
@@ -404,28 +365,23 @@ class GrafanaAgentCharm(CharmBase):
                 }
             )
 
-        if self.is_machine:
-            configs.append(
-                {
-                    "name": "log_file_scraper",
-                    "clients": self._loki_consumer.loki_endpoints,
-                    "scrape_configs": [
-                        {
-                            "job_name": "varlog",
-                            "static_configs": {
-                                "labels": {
-                                    "__path__": "/var/log/*",
-                                    "__path_exclude__": "/var/log/positions.yaml",
-                                    **self._principal_labels,
-                                }
-                            },
-                        },
-                        {"job_name": "syslog", "journal": {"labels": self._principal_labels}},
-                    ],
-                }
-            )
+        configs.extend(self._additional_log_configs)  # type: ignore
+        return {"configs": configs} if configs else {}
 
-        return {"logs": {"configs": configs}}
+    @property
+    def _instance_topology(self) -> Dict[str, str]:
+        """Return a default topology which may be overridden by children."""
+        return {
+            "juju_model": self.model.name,
+            "juju_model_uuid": self.model.uuid,
+            "juju_application": self.model.app.name,
+            "juju_unit": self.model.unit.name,
+        }
+
+    @property
+    def _instance_name(self) -> str:
+        """Return the instance name as interpolated topology values."""
+        return "_".join([v for v in self._instance_topology.values()])
 
     def _reload_config(self, attempts: int = 10) -> None:
         """Reload the config file.
@@ -457,10 +413,9 @@ class GrafanaAgentCharm(CharmBase):
         """
         if not self.is_ready:
             return None
-        version_output = self.agent_version_output()
         # Output looks like this:
         # agent, version v0.26.1 (branch: HEAD, revision: 2b88be37)
-        result = re.search(r"v(\d*\.\d*\.\d*)", version_output)
+        result = re.search(r"v(\d*\.\d*\.\d*)", self.agent_version_output())
         if result is None:
             return result
         return result.group(1)

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -136,11 +136,6 @@ class GrafanaAgentCharm(CharmBase):
         raise NotImplementedError("Please override the restart method")
 
     @property
-    def is_machine(self) -> bool:
-        """Check if this is a machine charm."""
-        raise NotImplementedError("Please override the is_machine method")
-
-    @property
     def _additional_integrations(self) -> Dict[str, Any]:
         """Additional per-type integrations to inject."""
         raise NotImplementedError("Please override the _additional_integrations method")

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -350,7 +350,7 @@ class GrafanaAgentCharm(CharmBase):
                 {
                     "name": "push_api_server",
                     "clients": self._loki_consumer.loki_endpoints,
-                    "positions": {"filename": "/tmp/positions.yaml"},
+                    "positions": {"filename": self._promtail_positions},
                     "scrape_configs": [
                         {
                             "job_name": "loki",

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -113,11 +113,6 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         """Restart grafana agent."""
         self._container.restart("agent")
 
-    @property
-    def is_machine(self) -> bool:
-        """Check if this is a machine charm."""
-        return False
-
 
 if __name__ == "__main__":
     main(GrafanaAgentK8sCharm)

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -6,7 +6,7 @@
 """A  juju charm for Grafana Agent on Kubernetes."""
 import logging
 import pathlib
-from typing import Union
+from typing import Any, Dict, List, Union
 
 import yaml
 from charms.observability_libs.v1.kubernetes_service_patch import (
@@ -43,7 +43,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         Args:
             event: The event object of the pebble ready event
         """
-        self._container.push(CONFIG_PATH, yaml.dump(self._config_file()), make_dirs=True)
+        self._container.push(CONFIG_PATH, yaml.dump(self._generate_config()), make_dirs=True)
 
         pebble_layer = {
             "summary": "agent layer",
@@ -72,6 +72,16 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     def is_ready(self):
         """Checks if the charm is ready for configuration."""
         return self._container.can_connect()
+
+    @property
+    def _additional_integrations(self) -> Dict:
+        """No additions for k8s charms."""
+        return {}
+
+    @property
+    def _additional_log_configs(self) -> List[Dict[str, Any]]:
+        """Additional per-type integrations to inject."""
+        return []
 
     def agent_version_output(self) -> str:
         """Runs `agent -version` and returns the output.

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -132,11 +132,6 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         subprocess.run(["sudo", "snap", "restart", self._service])
 
     @property
-    def is_machine(self) -> bool:
-        """Check if this is a machine charm."""
-        return True
-
-    @property
     def _is_installed(self) -> bool:
         """Check if the Grafana Agent snap is installed."""
         package_check = subprocess.run("snap list | grep grafana-agent", shell=True)

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -171,7 +171,6 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
                         "static_configs": {
                             "labels": {
                                 "__path__": "/var/log/*log",
-                                "__path_exclude__": "/var/log/positions.yaml",
                                 **self._principal_labels,
                             }
                         },

--- a/tests/unit/test_alerts.py
+++ b/tests/unit/test_alerts.py
@@ -98,7 +98,7 @@ LOKI_ALERT_RULES = {
 @patch.object(Container, "restart", new=lambda x, y: True)
 @patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestAlertIngestion(unittest.TestCase):
-    @patch("grafana_agent.KubernetesServicePatch", lambda x, y: None)
+    @patch("charm.KubernetesServicePatch", lambda x, y: None)
     @patch("grafana_agent.METRICS_RULES_SRC_PATH", tempfile.mkdtemp())
     @patch("grafana_agent.METRICS_RULES_DEST_PATH", tempfile.mkdtemp())
     @patch("grafana_agent.LOKI_RULES_SRC_PATH", tempfile.mkdtemp())

--- a/tests/unit/test_scrape_configuration.py
+++ b/tests/unit/test_scrape_configuration.py
@@ -246,7 +246,7 @@ class TestScrapeConfiguration(unittest.TestCase):
                         {"url": "http://loki0:3100:/loki/api/v1/push"},
                         {"url": "http://loki1:3100:/loki/api/v1/push"},
                     ],
-                    "positions": {"filename": "/tmp/positions.yaml"},
+                    "positions": {"filename": "/run/promtail-positions.yaml"},
                     "scrape_configs": [
                         {
                             "job_name": "loki",


### PR DESCRIPTION
## Issue
Make the codebase less muddy.

## Solution
Move machine agent stuff (`*_primary`) out of the main class, sync up config locations/generation so it's not a series of appended dicts from different places. 

Create methods to be overridden for per-machine/k8s config block additions (this also makes the `is_machine` method unnecessary), which are appended as part of the "wholesale" config generation in the main class body.

Fix the unit tests.
