### PR TITLE
add option for tls insecure skip verify

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,12 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+options:
+  tls_insecure_skip_verify:
+    description: |
+      Flag to skip the verification for insecure TLS.
+      If "true", self-signed certs can be seamlessly used; this setting
+      will be applied to all of the Agent configurations (Prometheus,
+      Loki).
+    type: boolean
+    default: false

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -249,8 +249,8 @@ class GrafanaAgentCharm(CharmBase):
         """Add TLS information to Prometheus and Loki endpoints."""
         prometheus_endpoints = self._remote_write.endpoints
         loki_endpoints = self._loki_consumer.loki_endpoints
-        for e in prometheus_endpoints + loki_endpoints:
-            e["tls_config"] = {
+        for endpoint in prometheus_endpoints + loki_endpoints:
+            endpoint["tls_config"] = {
                 "insecure_skip_verify": self.model.config.get("tls_insecure_skip_verify")
             }
         return prometheus_endpoints, loki_endpoints

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -146,10 +146,11 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     @property
     def _additional_log_configs(self) -> List[Dict[str, Any]]:
         """Additional logging configuration for machine charms."""
+        _, loki_endpoints = self._enrich_endpoints()
         return [
             {
                 "name": "log_file_scraper",
-                "clients": self._loki_consumer.loki_endpoints,
+                "clients": loki_endpoints,
                 "positions": {"filename": self._promtail_positions},
                 "scrape_configs": [
                     {

--- a/tests/unit/test_scrape_configuration.py
+++ b/tests/unit/test_scrape_configuration.py
@@ -111,14 +111,28 @@ class TestScrapeConfiguration(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             "prometheus/0",
-            {"remote_write": json.dumps({"url": "http://1.1.1.1:9090/api/v1/write"})},
+            {
+                "remote_write": json.dumps(
+                    {
+                        "url": "http://1.1.1.1:9090/api/v1/write",
+                        "tls_config": {"insecure_skip_verify": False},
+                    }
+                )
+            },
         )
 
         self.harness.add_relation_unit(rel_id, "prometheus/1")
         self.harness.update_relation_data(
             rel_id,
             "prometheus/1",
-            {"remote_write": json.dumps({"url": "http://1.1.1.2:9090/api/v1/write"})},
+            {
+                "remote_write": json.dumps(
+                    {
+                        "url": "http://1.1.1.2:9090/api/v1/write",
+                        "tls_config": {"insecure_skip_verify": False},
+                    }
+                )
+            },
         )
 
         expected_config: Dict[str, Any] = {
@@ -128,8 +142,14 @@ class TestScrapeConfiguration(unittest.TestCase):
                     "relabel_configs": REWRITE_CONFIGS,
                 },
                 "prometheus_remote_write": [
-                    {"url": "http://1.1.1.2:9090/api/v1/write"},
-                    {"url": "http://1.1.1.1:9090/api/v1/write"},
+                    {
+                        "url": "http://1.1.1.2:9090/api/v1/write",
+                        "tls_config": {"insecure_skip_verify": False},
+                    },
+                    {
+                        "url": "http://1.1.1.1:9090/api/v1/write",
+                        "tls_config": {"insecure_skip_verify": False},
+                    },
                 ],
             },
             "metrics": {
@@ -138,8 +158,14 @@ class TestScrapeConfiguration(unittest.TestCase):
                     {
                         "name": "agent_scraper",
                         "remote_write": [
-                            {"url": "http://1.1.1.2:9090/api/v1/write"},
-                            {"url": "http://1.1.1.1:9090/api/v1/write"},
+                            {
+                                "url": "http://1.1.1.2:9090/api/v1/write",
+                                "tls_config": {"insecure_skip_verify": False},
+                            },
+                            {
+                                "url": "http://1.1.1.1:9090/api/v1/write",
+                                "tls_config": {"insecure_skip_verify": False},
+                            },
                         ],
                         "scrape_configs": [],
                     }
@@ -163,11 +189,21 @@ class TestScrapeConfiguration(unittest.TestCase):
 
         self.assertEqual(
             config["integrations"]["prometheus_remote_write"],
-            [{"url": "http://1.1.1.1:9090/api/v1/write"}],
+            [
+                {
+                    "url": "http://1.1.1.1:9090/api/v1/write",
+                    "tls_config": {"insecure_skip_verify": False},
+                }
+            ],
         )
         self.assertEqual(
             config["metrics"]["configs"][0]["remote_write"],
-            [{"url": "http://1.1.1.1:9090/api/v1/write"}],
+            [
+                {
+                    "url": "http://1.1.1.1:9090/api/v1/write",
+                    "tls_config": {"insecure_skip_verify": False},
+                }
+            ],
         )
 
         # Test scale to zero
@@ -243,8 +279,14 @@ class TestScrapeConfiguration(unittest.TestCase):
                 {
                     "name": "push_api_server",
                     "clients": [
-                        {"url": "http://loki0:3100:/loki/api/v1/push"},
-                        {"url": "http://loki1:3100:/loki/api/v1/push"},
+                        {
+                            "url": "http://loki0:3100:/loki/api/v1/push",
+                            "tls_config": {"insecure_skip_verify": False},
+                        },
+                        {
+                            "url": "http://loki1:3100:/loki/api/v1/push",
+                            "tls_config": {"insecure_skip_verify": False},
+                        },
                     ],
                     "positions": {"filename": "/run/promtail-positions.yaml"},
                     "scrape_configs": [


### PR DESCRIPTION
## Issue
Add a config option for insecure skip verify of TLS, so that self-signed certificates can be used.

## Solution
The `insecure_skip_verify` option is taken as a configuration parameter and passed when assembling the configuration, specifically to:
* [remote writes](https://grafana.com/docs/agent/latest/configuration/metrics-config/#metrics_instance_config)
* [integrations prometheus_remote_writes](https://grafana.com/docs/agent/latest/configuration/integrations/)
* [loki client endpoints](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#clients)


[OPENG-1232]: https://warthogs.atlassian.net/browse/OPENG-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ