### PR TITLE
Clear machine metadata relations

### DIFF
--- a/machine_metadata.yaml
+++ b/machine_metadata.yaml
@@ -6,7 +6,7 @@ name: grafana-agent
 description: |
   Grafana Agent Subordinate Charm
 summary: |
-  Grafana Agent is a telemetry collector for sending metrics, logs, 
+  Grafana Agent is a telemetry collector for sending metrics, logs,
   and trace data to the opinionated Grafana observability stack.
 maintainers:
     - Jose Massón <jose.masson@canonical.com>
@@ -23,10 +23,9 @@ source: https://github.com/canonical/grafana-agent-k8s-operator
 issues: https://github.com/canonical/grafana-agent-k8s-operator/issues
 
 subordinate: true
-series: 
+series:
   - jammy
   - focal
-
 
 requires:
   juju-info:
@@ -47,16 +46,3 @@ requires:
     interface: prometheus_remote_write
   logging-consumer:
     interface: loki_push_api
-
-  metrics-endpoint:
-    # This one most likely won't exist in the final product but the 
-    # lib crashes if we don't have it.
-    interface: prometheus_scrape
-    scope: container
-
-provides:
-  logging-provider:
-    # This one most likely won't exist in the final product but the 
-    # lib crashes if we don't have it.
-    interface: loki_push_api
-    scope: container

--- a/machine_metadata.yaml
+++ b/machine_metadata.yaml
@@ -46,5 +46,11 @@ requires:
 
   send-remote-write:
     interface: prometheus_remote_write
+
   logging-consumer:
     interface: loki_push_api
+
+provides:
+  grafana-dashboards-provider:
+    interface: grafana_dashboard
+    scope: container

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import yaml
+from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer
 from charms.prometheus_k8s.v0.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,
@@ -84,6 +85,15 @@ class GrafanaAgentCharm(CharmBase):
 
         self._loki_consumer = LokiPushApiConsumer(
             self, relation_name="logging-consumer", alert_rules_path=self.loki_rules_paths.dest
+        )
+
+        self._grafana_dashboards_provider = GrafanaDashboardProvider(
+            self,
+            relation_name="grafana-dashboards-provider",
+            dashboards_path=self.dashboard_paths.dest,
+        )
+        self.framework.observe(
+            self._grafana_dashboards_provider.on.dashboard_status_changed, self._dashboards_changed
         )
 
         self.framework.observe(self.on.upgrade_charm, self._update_metrics_alerts)

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -11,11 +11,10 @@ from collections import namedtuple
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import yaml
-from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer, LokiPushApiProvider
+from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer
 from charms.prometheus_k8s.v0.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,
 )
-from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from ops.charm import CharmBase, RelationChangedEvent
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import APIError, PathError
@@ -53,6 +52,8 @@ class GrafanaAgentCharm(CharmBase):
     _grpc_listen_port = 3600
 
     def __init__(self, *args):
+        if type(self) == GrafanaAgentCharm:
+            raise TypeError("<GrafanaAgentCharm> should not be directly instantiated")
         super().__init__(*args)
 
         self.loki_rules_paths = RulesMapping(
@@ -71,28 +72,19 @@ class GrafanaAgentCharm(CharmBase):
         self._remote_write = PrometheusRemoteWriteConsumer(
             self, alert_rules_path=self.metrics_rules_paths.dest
         )
-        self._scrape = MetricsEndpointConsumer(self)
 
         self._loki_consumer = LokiPushApiConsumer(
             self, relation_name="logging-consumer", alert_rules_path=self.loki_rules_paths.dest
         )
-        self._loki_provider = LokiPushApiProvider(
-            self, relation_name="logging-provider", port=self._http_listen_port
-        )
 
-        self.framework.observe(self.on.upgrade_charm, self._metrics_alerts)
-        self.framework.observe(self.on.upgrade_charm, self._loki_alerts)
+        self.framework.observe(self.on.upgrade_charm, self._update_metrics_alerts)
+        self.framework.observe(self.on.upgrade_charm, self._update_loki_alerts)
 
         self.framework.observe(
             self._remote_write.on.endpoints_changed, self.on_remote_write_changed
         )
-        self.framework.observe(self._remote_write.on.endpoints_changed, self._metrics_alerts)
-
-        self.framework.observe(self._scrape.on.targets_changed, self.on_scrape_targets_changed)
-        self.framework.observe(self._scrape.on.targets_changed, self._metrics_alerts)
-
         self.framework.observe(
-            self._loki_provider.on.loki_push_api_alert_rules_changed, self._loki_alerts
+            self._remote_write.on.endpoints_changed, self._update_metrics_alerts
         )
 
         self.framework.observe(
@@ -145,20 +137,32 @@ class GrafanaAgentCharm(CharmBase):
         """Additional per-type integrations to inject."""
         raise NotImplementedError("Please override the _additional_log_configs method")
 
+    def metrics_rules(self) -> list:
+        """Return a list of metrics rules."""
+        raise NotImplementedError("Please override the metrics_rules method")
+
+    def metrics_jobs(self) -> list:
+        """Return a list of metrics scrape jobs."""
+        raise NotImplementedError("Please override the metrics_jobs method")
+
+    def logs_rules(self) -> list:
+        """Return a list of logging rules."""
+        raise NotImplementedError("Please override the logs_rules method")
+
     # End: Abstract Methods
 
-    def _metrics_alerts(self, event):
+    def _update_metrics_alerts(self, event):
         self.update_alerts_rules(
             event,
-            alerts_func=self._scrape.alerts,
+            alerts_func=self.metrics_rules(),
             reload_func=self._remote_write.reload_alerts,
             mapping=self.metrics_rules_paths,
         )
 
-    def _loki_alerts(self, event):
+    def _update_loki_alerts(self, event):
         self.update_alerts_rules(
             event,
-            alerts_func=self._loki_provider.alerts,
+            alerts_func=self.logs_rules,
             reload_func=self._loki_consumer._reinitialize_alert_rules,
             mapping=self.loki_rules_paths,
         )
@@ -279,7 +283,7 @@ class GrafanaAgentCharm(CharmBase):
                 "configs": [
                     {
                         "name": "agent_scraper",
-                        "scrape_configs": self._scrape.jobs(),
+                        "scrape_configs": self.metrics_jobs(),
                         "remote_write": prometheus_endpoints,
                     }
                 ],

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -9,10 +9,12 @@ import pathlib
 from typing import Any, Dict, List, Union
 
 import yaml
+from charms.loki_k8s.v0.loki_push_api import LokiPushApiProvider
 from charms.observability_libs.v1.kubernetes_service_patch import (
     KubernetesServicePatch,
     ServicePort,
 )
+from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from ops.main import main
 
 from grafana_agent import CONFIG_PATH, GrafanaAgentCharm
@@ -36,6 +38,17 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         )
 
         self.framework.observe(self.on.agent_pebble_ready, self.on_pebble_ready)
+
+        self._scrape = MetricsEndpointConsumer(self)
+        self.framework.observe(self._scrape.on.targets_changed, self.on_scrape_targets_changed)
+        self.framework.observe(self._scrape.on.targets_changed, self._update_metrics_alerts)
+
+        self._loki_provider = LokiPushApiProvider(
+            self, relation_name="logging-provider", port=self._http_listen_port
+        )
+        self.framework.observe(
+            self._loki_provider.on.loki_push_api_alert_rules_changed, self._update_loki_alerts
+        )
 
     def on_pebble_ready(self, _) -> None:
         """Event handler for the pebble ready event.
@@ -67,6 +80,18 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
                 "Cannot set workload version at this time: could not get Alertmanager version."
             )
         self._update_status()
+
+    def metrics_rules(self):
+        """Return a list of metrics rules."""
+        return self._scrape.alerts
+
+    def metrics_jobs(self):
+        """Return a list of metrics scrape jobs."""
+        return self._scrape.jobs()
+
+    def logs_rules(self):
+        """Return a list of logging rules."""
+        return self._loki_provider.alerts
 
     @property
     def is_ready(self):

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -80,6 +80,18 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         if self._is_installed:
             raise GrafanaAgentInstallError("Failed to uninstall grafana-agent")
 
+    def metrics_rules(self) -> list:
+        """Return a list of metrics rules."""
+        return []
+
+    def metrics_jobs(self) -> list:
+        """Return a list of metrics scrape jobs."""
+        return []
+
+    def logs_rules(self) -> list:
+        """Return a list of logging rules."""
+        return []
+
     @property
     def is_ready(self):
         """Checks if the charm is ready for configuration."""


### PR DESCRIPTION
## Issue
Afaiu, in order to remove the two relations in machine's metadata that `cos_machine` is intended to replace, we would need to further separate between the machine and k8s codes.


## Solution
Remove from machine metadata:
- prometheus_scrape requirer
- loki_push_api provider


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
