### PR TITLE
Machine charm lib logs forwarding

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_machine.py
+++ b/lib/charms/grafana_agent/v0/cos_machine.py
@@ -245,6 +245,15 @@ class COSMachineRequirer(Object):
         return scrape_jobs
 
     @property
+    def snap_log_plugs(self) -> List[str]:
+        """Fetch logging plugs exposed by related snaps."""
+        plugs = set()
+        for relation in self._relations:
+            if targets := self._fetch_data_from_relation(relation, "logs", "targets"):
+                plugs.update(targets)
+        return list(plugs)
+
+    @property
     def logs_alerts(self) -> Dict[str, Any]:
         """Fetch log alerts."""
         alert_rules = {}


### PR DESCRIPTION
#95 adds the cos-machine charm lib

This PR extracts the snap-plugs list from the relation and hands it over to the charm, which can then do what's appropriate, i.e.
- snap connect gagent:logs {snap-plug}
- make sure the $SNAP/shared-logs dir is monitored 