### PR TITLE
Rename cos-machine to cos-agent

### DIFF
--- a/INTEGRATING.md
+++ b/INTEGRATING.md
@@ -86,7 +86,7 @@ from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 
 class MyOperatorCharm(CharmBase):
     def __init__(self, *args):
-        ....
+        ...
         self._logging = LogProxyConsumer(self, relation_name="logging", log_files=logs_files)
 ```
 
@@ -104,7 +104,7 @@ Once the relation is established, Zinc charm can start sending logs to Grafana A
 #### This charm
 
 ```yaml
-provides
+provides:
   grafana-dashboard:
     interface: grafana_dashboard
 ```

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -3,26 +3,26 @@
 
 r"""## Overview.
 
-This library can be used to manage the cos_machine relation interface:
+This library can be used to manage the cos_agent relation interface:
 
-- `COSMachineProvider`: Use in machine charms that need to have a workload's metrics
+- `COSAgentProvider`: Use in machine charms that need to have a workload's metrics
   or logs scraped, or forward rule files or dashboards to Prometheus, Loki or Grafana through
   the Grafana Agent machine charm.
 
-- `COSMachineConsumer`: Used in the Grafana Agent machine charm to manage the requrier side of 
-  the `cos_machine` interface.
+- `COSAgentConsumer`: Used in the Grafana Agent machine charm to manage the requrier side of
+  the `cos_agent` interface.
 
 
-## COSMachineProvider Library Usage
+## COSAgentProvider Library Usage
 
-Grafana Agent machine Charmed Operator interacts with its clients using the cos_machine library.
-Charms seeking to send telemetry, must do so using the `COSMachineProvider` object from
+Grafana Agent machine Charmed Operator interacts with its clients using the cos_agent library.
+Charms seeking to send telemetry, must do so using the `COSAgentProvider` object from
 this charm library.
 
-Using the `COSMachineProvider` object only requires instantiating it,
+Using the `COSAgentProvider` object only requires instantiating it,
 typically in the `__init__` method of your charm (the one which sends telemetry).
 
-The constructor of `COSMachineProvider` has only one required and eight optional parameters:
+The constructor of `COSAgentProvider` has only one required and eight optional parameters:
 
 ```python
     def __init__(
@@ -39,22 +39,23 @@ The constructor of `COSMachineProvider` has only one required and eight optional
     ):
 ```
 
-### Paramenters
+### Parameters
 
-- `charm`: The instance of the charm that instantiates `COSMachineProvider`, tipically `self`.
+- `charm`: The instance of the charm that instantiates `COSAgentProvider`, typically `self`.
 
-- `relation_name`: If your charmed operator uses a relation name other than `cos-machine` to use
-    the `cos_machine` interface, this is where you have to specify that.
+- `relation_name`: If your charmed operator uses a relation name other than `cos-agent` to use
+    the `cos_agent` interface, this is where you have to specify that.
 
 - `metrics_endpoints`: In this parameter you can specify the metrics endpoints that Grafana Agent
     machine Charmed Operator will scrape.
 
-- `metrics_rules_dir`: The directory in which the Charmed Operator stores its metrics alert rules files.
+- `metrics_rules_dir`: The directory in which the Charmed Operator stores its metrics alert rules
+  files.
 
 - `logs_rules_dir`: The directory in which the Charmed Operator stores its logs alert rules files.
 
-- `recurse_rules_dirs`: This paramenters set wheter Grafana Agent machine Charmed Operator has to search
-    alert rules files recursively in the previous two directories or not.
+- `recurse_rules_dirs`: This parameters set whether Grafana Agent machine Charmed Operator has to
+  search alert rules files recursively in the previous two directories or not.
 
 - `log_slots`: Snap slots to connect to for scraping logs in the form ["snap-name:slot", ...].
 
@@ -68,12 +69,12 @@ The constructor of `COSMachineProvider` has only one required and eight optional
 In order to use this object the following should be in the `charm.py` file.
 
 ```python
-from charms.grafana_agent.v0.cos_machine import COSMachineProvider
+from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 ...
 class TelemetryProviderCharm(CharmBase):
     def __init__(self, *args):
         ...
-        self._grafana_agent = COSMachineProvider(self)
+        self._grafana_agent = COSAgentProvider(self)
 ```
 
 ### Example 2 - Full instrumentation:
@@ -81,14 +82,14 @@ class TelemetryProviderCharm(CharmBase):
 In order to use this object the following should be in the `charm.py` file.
 
 ```python
-from charms.grafana_agent.v0.cos_machine import COSMachineProvider
+from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 ...
 class TelemetryProviderCharm(CharmBase):
     def __init__(self, *args):
         ...
-        self._grafana_agent = COSMachineProvider(
+        self._grafana_agent = COSAgentProvider(
             self,
-            relation_name="custom-cos-machine",
+            relation_name="custom-cos-agent",
             metrics_endpoints=[
                 {"path": "/metrics", "port": 9000},
                 {"path": "/metrics", "port": 9001},
@@ -103,13 +104,13 @@ class TelemetryProviderCharm(CharmBase):
         )
 ```
 
-## COSMachineConsumer Library Usage
+## COSAgentConsumer Library Usage
 
 This object may be used by any Charmed Operator which gathers telemetry data by
-implementing the consumer side of the `cos_machine` interface.
+implementing the consumer side of the `cos_agent` interface.
 For instance Grafana Agent machine Charmed Operator.
 
-For this purposes the charm needs to instantiate the `COSMachineConsumer` object with one mandatory
+For this purposes the charm needs to instantiate the `COSAgentConsumer` object with one mandatory
 and two optional arguments.
 
 ### Paramenters
@@ -117,11 +118,11 @@ and two optional arguments.
 - `charm`: A reference to the parent (Grafana Agent machine) charm.
 
 - `relation_name`: The name of the relation that the charm uses to interact
-  with its clients that provides telemetry data using the `COSMachineProvider` object.
+  with its clients that provides telemetry data using the `COSAgentProvider` object.
 
   If provided, this relation name must match a provided relation in metadata.yaml with the
-  `cos_machine` interface.
-  The default value of this arguments is "cos-machine".
+  `cos_agent` interface.
+  The default value of this arguments is "cos-agent".
 
 - `refresh_events`: List of events on which to refresh relation data.
 
@@ -131,12 +132,12 @@ and two optional arguments.
 In order to use this object the following should be in the `charm.py` file.
 
 ```python
-from charms.grafana_agent.v0.cos_machine import COSMachineConsumer
+from charms.grafana_agent.v0.cos_agent import COSAgentConsumer
 ...
 class GrafanaAgentMachineCharm(GrafanaAgentCharm)
     def __init__(self, *args):
         ...
-        self._cos = COSMachineRequirer(self)
+        self._cos = COSAgentRequirer(self)
 ```
 
 
@@ -145,14 +146,14 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm)
 In order to use this object the following should be in the `charm.py` file.
 
 ```python
-from charms.grafana_agent.v0.cos_machine import COSMachineConsumer
+from charms.grafana_agent.v0.cos_agent import COSAgentConsumer
 ...
 class GrafanaAgentMachineCharm(GrafanaAgentCharm)
     def __init__(self, *args):
         ...
-        self._cos = COSMachineRequirer(
+        self._cos = COSAgentRequirer(
             self,
-            relation_name="cos-machine-consumer",
+            relation_name="cos-agent-consumer",
             refresh_events=["update-status", "upgrade-charm"],
         )
 ```
@@ -179,7 +180,7 @@ LIBPATCH = 1
 
 PYDEPS = ["cosl"]
 
-DEFAULT_RELATION_NAME = "cos-machine"
+DEFAULT_RELATION_NAME = "cos-agent"
 DEFAULT_METRICS_ENDPOINT = {
     "path": "/metrics",
     "port": 80,
@@ -189,8 +190,8 @@ logger = logging.getLogger(__name__)
 SnapEndpoint = namedtuple("SnapEndpoint", "owner, name")
 
 
-class COSMachineProvider(Object):
-    """Integration endpoint wrapper for the provider side of the cos_machine interface."""
+class COSAgentProvider(Object):
+    """Integration endpoint wrapper for the provider side of the cos_agent interface."""
 
     def __init__(
         self,
@@ -204,7 +205,7 @@ class COSMachineProvider(Object):
         dashboard_dirs: Optional[List[str]] = None,
         refresh_events: Optional[List] = None,
     ):
-        """Create a COSMachineProvider instance.
+        """Create a COSAgentProvider instance.
 
         Args:
             charm: The `CharmBase` instance that is instantiating this object.
@@ -313,20 +314,20 @@ class COSMachineProvider(Object):
         return base64.b64encode(lzma.compress(content)).decode("utf-8")
 
 
-class COSMachineDataChanged(EventBase):
-    """Event emitted by `COSMachineRequirer` when relation data changes."""
+class COSAgentDataChanged(EventBase):
+    """Event emitted by `COSAgentRequirer` when relation data changes."""
 
 
-class COSMachineRequirerEvents(ObjectEvents):
-    """`COSMachineRequirer` events."""
+class COSAgentRequirerEvents(ObjectEvents):
+    """`COSAgentRequirer` events."""
 
-    data_changed = EventSource(COSMachineDataChanged)
+    data_changed = EventSource(COSAgentDataChanged)
 
 
-class COSMachineRequirer(Object):
-    """Integration endpoint wrapper for the Requirer side of the cos_machine interface."""
+class COSAgentRequirer(Object):
+    """Integration endpoint wrapper for the Requirer side of the cos_agent interface."""
 
-    on = COSMachineRequirerEvents()
+    on = COSAgentRequirerEvents()
 
     def __init__(
         self,
@@ -334,7 +335,7 @@ class COSMachineRequirer(Object):
         relation_name: str = DEFAULT_RELATION_NAME,
         refresh_events: Optional[List[str]] = None,
     ):
-        """Create a COSMachineRequirer instance.
+        """Create a COSAgentRequirer instance.
 
         Args:
             charm: The `CharmBase` instance that is instantiating this object.

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -9,7 +9,7 @@ This library can be used to manage the cos_agent relation interface:
   or logs scraped, or forward rule files or dashboards to Prometheus, Loki or Grafana through
   the Grafana Agent machine charm.
 
-- `COSAgentConsumer`: Used in the Grafana Agent machine charm to manage the requrier side of
+- `COSAgentConsumer`: Used in the Grafana Agent machine charm to manage the requirer side of
   the `cos_agent` interface.
 
 

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -174,7 +174,7 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 from ops.model import Relation
 from ops.testing import CharmType
 
-LIBID = "1212"  # FIXME: Need to get a valid ID from charmhub
+LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
 LIBPATCH = 1
 

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -110,10 +110,10 @@ This object may be used by any Charmed Operator which gathers telemetry data by
 implementing the consumer side of the `cos_agent` interface.
 For instance Grafana Agent machine Charmed Operator.
 
-For this purposes the charm needs to instantiate the `COSAgentConsumer` object with one mandatory
+For this purpose the charm needs to instantiate the `COSAgentConsumer` object with one mandatory
 and two optional arguments.
 
-### Paramenters
+### Parameters
 
 - `charm`: A reference to the parent (Grafana Agent machine) charm.
 
@@ -122,7 +122,7 @@ and two optional arguments.
 
   If provided, this relation name must match a provided relation in metadata.yaml with the
   `cos_agent` interface.
-  The default value of this arguments is "cos-agent".
+  The default value of this argument is "cos-agent".
 
 - `refresh_events`: List of events on which to refresh relation data.
 
@@ -213,7 +213,7 @@ class COSAgentProvider(Object):
             metrics_endpoints: List of endpoints in the form [{"path": path, "port": port}, ...].
             metrics_rules_dir: Directory where the metrics rules are stored.
             logs_rules_dir: Directory where the logs rules are stored.
-            recurse_rules_dirs: Whether or not to recurse into rule paths.
+            recurse_rules_dirs: Whether to recurse into rule paths.
             log_slots: Snap slots to connect to for scraping logs
                 in the form ["snap-name:slot", ...].
             dashboard_dirs: Directory where the dashboards are stored.
@@ -340,7 +340,7 @@ class COSAgentRequirer(Object):
         Args:
             charm: The `CharmBase` instance that is instantiating this object.
             relation_name: The name of the relation to communicate over.
-            refresh_events: List of events on which to resfresh relation data.
+            refresh_events: List of events on which to refresh relation data.
         """
         super().__init__(charm, relation_name)
         self._charm = charm

--- a/machine_metadata.yaml
+++ b/machine_metadata.yaml
@@ -36,12 +36,12 @@ requires:
     interface: juju-info
     scope: container
 
-  cos-machine:
+  cos-agent:
     description: |
-      `cos-machine` is a dedicated relation for the grafana agent machine
-      charm. it will allow you to set up custom scrape jobs, fetch files
+      `cos-agent` is a dedicated relation for the grafana agent machine
+      charm. It will allow you to set up custom scrape jobs, fetch files
       from arbitrary locations, send alert rules, dashboards, etc.
-    interface: cos_machine
+    interface: cos_agent
     scope: container
 
   send-remote-write:

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -304,7 +304,7 @@ class GrafanaAgentCharm(CharmBase):
             pass
 
         if config == old_config:
-            # Nothing changed, possibly new install. Set us active and move on.
+            # Nothing changed, possibly new installation. Set us active and move on.
             self.unit.status = ActiveStatus()
             return
 

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -382,7 +382,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
 
     @property
     def _snap_plugs_logging_configs(self) -> List[Dict[str, Any]]:
-        """One logging config for each separate snap connected over the logs endpoint."""
+        """One logging config for each separate snap connected over the "logs" endpoint."""
         agent_fstab = SnapFstab(Path("/var/lib/snapd/mount/snap.grafana-agent.fstab"))
 
         shared_logs_configs = []

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from charms.grafana_agent.v0.cos_machine import COSMachineRequirer
+from charms.grafana_agent.v0.cos_agent import COSAgentRequirer
 from charms.operator_libs_linux.v1 import snap
 from ops.main import main
 from ops.model import ActiveStatus, MaintenanceStatus, Relation, Unit
@@ -129,11 +129,11 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
 
     def __init__(self, *args):
         super().__init__(*args)
-        # technically, only one of 'cos-machine' and 'juju-info' are likely to ever be active at
+        # technically, only one of 'cos-agent' and 'juju-info' are likely to ever be active at
         # any given time. however, for the sake of understandability, we always set _cos, and
         # we always listen to juju-info-joined events even though one of the two paths will be
         # at all effects unused.
-        self._cos = COSMachineRequirer(self)
+        self._cos = COSAgentRequirer(self)
         self.snap = snap.SnapCache()["grafana-agent"]
         self.framework.observe(self._cos.on.data_changed, self._on_cos_data_changed)
         self.framework.observe(self.on["juju_info"].relation_joined, self._on_juju_info_joined)
@@ -310,14 +310,14 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
 
     @property
     def _principal_relation(self) -> Optional[Relation]:
-        """The cos-machine relation, if the charm we're related to supports it, else juju-info."""
-        # juju relate will do "the right thing" and default to cos-machine, falling back to
-        # juju-info if no cos-machine endpoint is available on the principal.
+        """The cos-agent relation, if the charm we're related to supports it, else juju-info."""
+        # juju relate will do "the right thing" and default to cos-agent, falling back to
+        # juju-info if no cos-agent endpoint is available on the principal.
         # Technically, if the charm is executing, there MUST be one of these two relations
         # (otherwise, the subordinate won't even execute). However, for the sake of juju maybe not
         # showing us the relation until after the first few install/start/config-changed, we err on
         # the safe side and type this as Optional.
-        return self.model.get_relation("cos-machine") or self.model.get_relation("juju-info")
+        return self.model.get_relation("cos-agent") or self.model.get_relation("juju-info")
 
     @property
     def principal_unit(self) -> Optional[Unit]:

--- a/tests/integration/loki-tester/README.md
+++ b/tests/integration/loki-tester/README.md
@@ -37,7 +37,7 @@ Make Loki tester send an error log
 juju run-action loki-tester/0 log-error message="some error message"
 ```
 
-Check a if the `log-error` action is triggering an alert by querrying
+Check if the `log-error` action is triggering an alert by querying
 the alerts raised by Loki.
 ```
 curl -G -s http://$(lokiaddr):3100/prometheus/api/v1/alerts

--- a/tests/integration/loki-tester/src/charm.py
+++ b/tests/integration/loki-tester/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""A Integration tester charm for Loki Operator."""
+"""An integration tester charm for Loki Operator."""
 
 import logging
 from multiprocessing import Queue
@@ -80,7 +80,7 @@ class LokiTesterCharm(CharmBase):
         for h in to_remove:
             logger.removeHandler(h)
 
-        # Add any missing loggers whichshould be there
+        # Add any missing loggers which should be there
         for h in to_add:
             logger.addHandler(h)
 

--- a/tests/scenario/test_machine_charm/test_scrape_configs.py
+++ b/tests/scenario/test_machine_charm/test_scrape_configs.py
@@ -39,7 +39,7 @@ def test_snap_endpoints():
     )
 
     cos_relation = Relation(
-        "cos-machine",
+        "cos-agent",
         remote_app_name="principal",
         remote_app_data={
             "config": json.dumps(

--- a/tests/unit/k8s/test_scrape_configuration.py
+++ b/tests/unit/k8s/test_scrape_configuration.py
@@ -286,7 +286,6 @@ class TestScrapeConfiguration(unittest.TestCase):
                             "tls_config": {"insecure_skip_verify": False},
                         },
                     ],
-                    "positions": {"filename": "/run/promtail-positions.yaml"},
                     "scrape_configs": [
                         {
                             "job_name": "loki",
@@ -298,8 +297,9 @@ class TestScrapeConfiguration(unittest.TestCase):
                             },
                         }
                     ],
-                }
-            ]
+                },
+            ],
+            "positions_directory": "/tmp/grafana-agent-positions",
         }
         self.assertEqual(
             DeepDiff(expected, self.harness.charm._loki_config, ignore_order=True), {}

--- a/tests/unit/machine/test_update_status.py
+++ b/tests/unit/machine/test_update_status.py
@@ -22,6 +22,10 @@ class TestUpdateStatus(unittest.TestCase):
         self.config_path_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = patch("charm.snap")
+        self.mock_snap = patcher.start()
+        self.addCleanup(patcher.stop)
+
         self.harness = Harness(GrafanaAgentCharm)
         self.harness.set_model_name(self.__class__.__name__)
 


### PR DESCRIPTION
## Issue
Lib/iface name has "machine" in it, which is redundant.


## Solution
Rename to `cos-agent`.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
