### PR TITLE
Fix dashboard copying

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 """Common logic for both k8s and machine charms for Grafana Agent."""
+import json
 import logging
 import os
 import pathlib
@@ -250,11 +251,9 @@ class GrafanaAgentCharm(CharmBase):
         shutil.rmtree(mapping.dest)
         shutil.copytree(mapping.src, mapping.dest)
         for dash in dashboards:
-            identifier = (
-                f'{dash.get("charm", "charm-name")}-{dash.get("relation_id", "rel_id")}',
-            )
-            file_handle = pathlib.Path(mapping.dest, "juju_{}.rules".format(identifier))
-            file_handle.write_text(yaml.dump(dash["content"]))
+            identifier = f'{dash.get("charm", "charm-name")}-{dash.get("relation_id", "rel_id")}'
+            file_handle = pathlib.Path(mapping.dest, "juju_{}.json".format(identifier))
+            file_handle.write_text(json.dumps(dash["content"]))
             logger.debug("updated dashboard file {}".format(file_handle.absolute()))
         reload_func()
 

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -252,7 +252,7 @@ class GrafanaAgentCharm(CharmBase):
         shutil.copytree(mapping.src, mapping.dest)
         for dash in dashboards:
             identifier = f'{dash.get("charm", "charm-name")}-{dash.get("relation_id", "rel_id")}'
-            file_handle = pathlib.Path(mapping.dest, "juju_{}.json".format(identifier))
+            file_handle = pathlib.Path(mapping.dest, f"juju_{identifier}.json")
             file_handle.write_text(json.dumps(dash["content"]))
             logger.debug("updated dashboard file {}".format(file_handle.absolute()))
         reload_func()


### PR DESCRIPTION
## Issue
When skeletonizing the dashboard copying, I got sidetracked with log labeling and forgot to go back to adjust the formatting.

Use `json.dumps`, not `yaml.dump`. Dashboards are JSON.

Give the dashboards the correct extension, and remove parens around the string format so the filename doesn't have oddly escaped characters.
