### PR TITLE
FIX Grafana dashboards files are stored in a bad format

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -176,7 +176,7 @@ from ops.testing import CharmType
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["cosl"]
 

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -461,12 +461,15 @@ class COSAgentRequirer(Object):
                 relation, "dashboards", "dashboards"
             ):
                 for dashboard in dashboard_data:
+                    content = self._decode_dashboard_content(dashboard)
+                    title = json.loads(content).get("title", "no_title")
                     dashboards.append(
                         {
                             "relation_id": str(relation.id),
                             # We don't have the remote charm name, but give us an identifier
                             "charm": f"{relation.name}-{relation.app.name if relation.app else 'unknown'}",
-                            "content": self._decode_dashboard_content(dashboard),
+                            "content": content,
+                            "title": title,
                         }
                     )
         return dashboards

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -249,13 +249,16 @@ class GrafanaAgentCharm(CharmBase):
 
         shutil.rmtree(mapping.dest)
         shutil.copytree(mapping.src, mapping.dest)
-        for dash in enumerate(dashboards):
-            charm = dash[1].get("charm", "charm-name")
-            rel_id = dash[1].get("relation_id", "rel_id")
-            identifier = f"{dash[0]}-{charm}-{rel_id}"
-            file_handle = pathlib.Path(mapping.dest, f"juju_{identifier}.json")
-            file_handle.write_text(dash[1]["content"], "utf-8")
-            logger.debug("updated dashboard file {file_handle.absolute()}")
+        for key, dash in enumerate(dashboards):
+            # Build dashboard custom filename
+            charm = dash.get("charm", "charm-name")
+            rel_id = dash.get("relation_id", "rel_id")
+            filename = f"juju_{key}-{charm}-{rel_id}.json"
+
+            file_handle = pathlib.Path(mapping.dest, filename)
+            file_handle.write_text(dash["content"], "utf-8")
+            logger.debug("updated dashboard file %s", file_handle.absolute())
+
         reload_func()
 
     def on_scrape_targets_changed(self, _event) -> None:

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -249,13 +249,13 @@ class GrafanaAgentCharm(CharmBase):
 
         shutil.rmtree(mapping.dest)
         shutil.copytree(mapping.src, mapping.dest)
-        for dash in dashboards:
-            identifier = (
-                f'{dash.get("charm", "charm-name")}-{dash.get("relation_id", "rel_id")}',
-            )
-            file_handle = pathlib.Path(mapping.dest, "juju_{}.rules".format(identifier))
-            file_handle.write_text(yaml.dump(dash["content"]))
-            logger.debug("updated dashboard file {}".format(file_handle.absolute()))
+        for dash in enumerate(dashboards):
+            charm = dash[1].get("charm", "charm-name")
+            rel_id = dash[1].get("relation_id", "rel_id")
+            identifier = f"{dash[0]}-{charm}-{rel_id}"
+            file_handle = pathlib.Path(mapping.dest, f"juju_{identifier}.json")
+            file_handle.write_text(dash[1]["content"], "utf-8")
+            logger.debug("updated dashboard file {file_handle.absolute()}")
         reload_func()
 
     def on_scrape_targets_changed(self, _event) -> None:

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -249,15 +249,16 @@ class GrafanaAgentCharm(CharmBase):
 
         shutil.rmtree(mapping.dest)
         shutil.copytree(mapping.src, mapping.dest)
-        for key, dash in enumerate(dashboards):
+        for dash in dashboards:
             # Build dashboard custom filename
             charm = dash.get("charm", "charm-name")
             rel_id = dash.get("relation_id", "rel_id")
-            filename = f"juju_{key}-{charm}-{rel_id}.json"
+            title = dash.get("title").replace(" ", "_").lower()
+            filename = f"juju_{title}-{charm}-{rel_id}.json"
 
-            file_handle = pathlib.Path(mapping.dest, filename)
-            file_handle.write_text(dash["content"], "utf-8")
-            logger.debug("updated dashboard file %s", file_handle.absolute())
+            with open(pathlib.Path(mapping.dest, filename), mode="w", encoding="utf-8") as f:
+                f.write(dash["content"])
+                logger.debug("updated dashboard file %s", f.name)
 
         reload_func()
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR fixes #135 

## Solution
<!-- A summary of the solution addressing the above issue -->

This PR fixes:
- The dashboard's malformed files names
- Dashboards content: There is no need to transform the content of the dashboard, since the [lib returns a string](https://github.com/canonical/grafana-agent-k8s-operator/blob/machine_charm/lib/charms/grafana_agent/v0/cos_agent.py#L475)
- Files overwrite: As we generated the same name, the files were overwritten.
