### PR TITLE
Set BlockedStatus per relation

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -389,8 +389,8 @@ class COSAgentRequirer(Object):
     def _relation_unit(relation: Relation) -> Optional[Unit]:
         """Return the principal unit for a relation."""
         if relation and relation.units:
-            # TODO: Is the implied order guaranteed?
-            #  I.e. is the principal guaranteed to be the first item in the list?
+            # With subordiante charms, relation.units is always either empty or has only the
+            # principal unit, so next(iter(...)) is fine.
             return next(iter(relation.units))
         return None
 

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -249,12 +249,18 @@ class COSAgentProvider(Object):
         for relation in relations:
             if relation.data:
                 if self._charm.unit.is_leader():
-                    relation.data[self._charm.app].update({"config": self._generate_application_databag_content()})
-                relation.data[self._charm.unit].update({"config": self._generate_unit_databag_content()})
+                    relation.data[self._charm.app].update(
+                        {"config": self._generate_application_databag_content()}
+                    )
+                relation.data[self._charm.unit].update(
+                    {"config": self._generate_unit_databag_content()}
+                )
 
     def _generate_application_databag_content(self) -> str:
         """Collate the data for each nested app databag and return it."""
-        # The application databag is divided in two chunks: metrics (alert rules only) and dashboards.
+        # The application databag is divided in three chunks: alert rules (metrics and logs) and
+        # dashboards.
+        # Scrape jobs and log slots are unit-dependent and are therefore stored in unit databag.
 
         data = {
             # primary key
@@ -275,6 +281,7 @@ class COSAgentProvider(Object):
     def _generate_unit_databag_content(self) -> str:
         """Collate the data for each nested unit databag and return it."""
         # The unit databag is divided in two chunks: metrics (scrape jobs only) and logs.
+        # Alert rules and dashboards are unit-independent and are therefore stored in app databag.
 
         data = {
             # primary key
@@ -382,9 +389,11 @@ class COSAgentRequirer(Object):
     def _relation_unit(relation: Relation) -> Optional[Unit]:
         """Return the principal unit for a relation."""
         if relation and relation.units:
+            # TODO: Is the implied order guaranteed?
+            #  I.e. is the principal guaranteed to be the first item in the list?
             return next(iter(relation.units))
         return None
-    
+
     @property
     def _relations(self):
         return self._charm.model.relations[self._relation_name]

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -59,6 +59,9 @@ class GrafanaAgentCharm(CharmBase):
     _http_listen_port = 3500
     _grpc_listen_port = 3600
 
+    # Property to facilitate centralized status update
+    mandatory_relation_pairs: list  # overridden
+
     def __new__(cls, *args: Any, **kwargs: Dict[Any, Any]):
         """Forbid the usage of GrafanaAgentCharm directly."""
         if cls is GrafanaAgentCharm:

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -289,16 +289,15 @@ class GrafanaAgentCharm(CharmBase):
             ("cos-agent", "logging-consumer"),
             ("cos-agent", "grafana-dashboards-consumer"),
         ]:
-            if relations := self.model.relations.get(incoming):
-                if len(relations):
-                    if not len(self.model.relations.get(outgoing, [])):
-                        logger.warning(
-                            "An incoming '%s' relation does not yet have a matching outgoing '%s' relation",
-                            incoming,
-                            outgoing,
-                        )
-                        self.unit.status = BlockedStatus(f"Missing relation: '{outgoing}'")
-                        return
+            if self.model.relations.get(incoming):
+                if not len(self.model.relations.get(outgoing, [])):
+                    logger.warning(
+                        "An incoming '%s' relation does not yet have a matching outgoing '%s' relation",
+                        incoming,
+                        outgoing,
+                    )
+                    self.unit.status = BlockedStatus(f"Missing relation: '{outgoing}'")
+                    return
 
         if not self.is_ready:
             self.unit.status = WaitingStatus("waiting for the agent to start")

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -344,6 +344,7 @@ class GrafanaAgentCharm(CharmBase):
         self._grafana_dashboards_provider._reinitialize_dashboard_data(
             inject_dropdowns=False
         )  # noqa
+        self._update_status()
 
     def _enrich_endpoints(self) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
         """Add TLS information to Prometheus and Loki endpoints."""

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -138,18 +138,22 @@ class GrafanaAgentCharm(CharmBase):
         self._update_metrics_alerts()
         self._update_loki_alerts()
         self._update_config()
+        self._update_status()
 
     def _on_loki_push_api_endpoint_joined(self, _event=None):
         """Rebuild the config with correct Loki sinks."""
         self._update_config()
+        self._update_status()
 
     def _on_loki_push_api_endpoint_departed(self, _event=None):
         """Rebuild the config with correct Loki sinks."""
         self._update_config()
+        self._update_status()
 
     def _on_config_changed(self, _event=None):
         """Rebuild the config."""
         self._update_config()
+        self._update_status()
 
     # Abstract Methods
     def agent_version_output(self) -> str:

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -27,6 +27,14 @@ SCRAPE_RELATION_NAME = "metrics-endpoint"
 class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     """K8s version of the Grafana Agent charm."""
 
+    # Pairs of (incoming, outgoing) relation names. If any 'incoming' is joined without a matching
+    # 'outgoing', the charm will block. Without an outgoing relation we may incur data loss.
+    mandatory_relation_pairs = [
+        ("metrics-endpoint", "send-remote-write"),
+        ("logging-provider", "logging-consumer"),
+        ("grafana-dashboards-consumer", "grafana-dashboards-provider"),
+    ]
+
     def __init__(self, *args):
         super().__init__(*args)
         self._container = self.unit.get_container(self._name)

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -133,6 +133,8 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         ("cos-agent", "send-remote-write"),
         ("cos-agent", "logging-consumer"),
         ("cos-agent", "grafana-dashboards-provider"),
+        ("juju-info", "send-remote-write"),
+        ("juju-info", "logging-consumer"),
     ]
 
     def __init__(self, *args):

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional, Union
 from charms.grafana_agent.v0.cos_agent import COSAgentRequirer
 from charms.operator_libs_linux.v1 import snap
 from ops.main import main
-from ops.model import ActiveStatus, MaintenanceStatus, Relation, Unit
+from ops.model import MaintenanceStatus, Relation, Unit
 
 from grafana_agent import GrafanaAgentCharm
 
@@ -127,6 +127,14 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
 
     service_name = "grafana-agent.grafana-agent"
 
+    # Pairs of (incoming, outgoing) relation names. If any 'incoming' is joined without a matching
+    # 'outgoing', the charm will block. Without an outgoing relation we may incur data loss.
+    mandatory_relation_pairs = [
+        ("cos-agent", "send-remote-write"),
+        ("cos-agent", "logging-consumer"),
+        ("cos-agent", "grafana-dashboards-provider"),
+    ]
+
     def __init__(self, *args):
         super().__init__(*args)
         # technically, only one of 'cos-agent' and 'juju-info' are likely to ever be active at
@@ -176,7 +184,8 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
             self.snap.start(enable=True)
         except snap.SnapError as e:
             raise GrafanaAgentServiceError("Failed to start grafana-agent") from e
-        self.unit.status = ActiveStatus("")
+
+        self._update_status()
 
     def _on_stop(self, _event) -> None:
         self.unit.status = MaintenanceStatus("Stopping grafana-agent snap")
@@ -184,6 +193,8 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
             self.snap.stop(disable=True)
         except snap.SnapError as e:
             raise GrafanaAgentServiceError("Failed to stop grafana-agent") from e
+
+        self._update_status()
 
     def _on_remove(self, _event) -> None:
         """Uninstall the Grafana Agent snap."""
@@ -253,7 +264,6 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
             self.snap.restart()
         except snap.SnapError as e:
             raise GrafanaAgentServiceError("Failed to restart grafana-agent") from e
-        self.unit.status = ActiveStatus("")
 
     @property
     def _is_installed(self) -> bool:

--- a/tests/unit/k8s/test_relation_status.py
+++ b/tests/unit/k8s/test_relation_status.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import patch
+
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Harness
+
+from charm import GrafanaAgentK8sCharm as GrafanaAgentCharm
+
+
+@patch("charm.KubernetesServicePatch", lambda *_, **__: None)
+class TestRelationStatus(unittest.TestCase):
+    @patch("charm.KubernetesServicePatch", lambda *_, **__: None)
+    def setUp(self, *unused):
+        patcher = patch.object(GrafanaAgentCharm, "_agent_version", property(lambda *_: "0.0.0"))
+        self.mock_version = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.harness = Harness(GrafanaAgentCharm)
+        self.harness.set_model_name(self.__class__.__name__)
+
+        self.addCleanup(self.harness.cleanup)
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+    def test_no_relations(self):
+        self.harness.charm.on.update_status.emit()
+        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+    def test_with_relations(self):
+        for incoming, outgoing in [
+            # K8s
+            ("logging-provider", "logging-consumer"),
+            ("metrics-endpoint", "send-remote-write"),
+            ("grafana-dashboards-provider", "grafana-dashboards-consumer"),
+        ]:
+            with self.subTest(incoming=incoming, outgoing=outgoing):
+                # WHEN an incoming relation is added
+                rel_id = self.harness.add_relation(incoming, "grafana-agent")
+                self.harness.add_relation_unit(rel_id, "grafana-agent/0")
+                self.harness.update_relation_data(rel_id, "grafana-agent/0", {"dummy": "value"})
+
+                # THEN the charm goes into blocked status
+                self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
+
+                # AND WHEN an appropriate outgoing relation is added
+                rel_id = self.harness.add_relation(outgoing, "grafana-agent")
+                self.harness.add_relation_unit(rel_id, "grafana-agent/0")
+
+                # THEN the charm goes into active status
+                self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)

--- a/tests/unit/k8s/test_relation_status.py
+++ b/tests/unit/k8s/test_relation_status.py
@@ -26,15 +26,21 @@ class TestRelationStatus(unittest.TestCase):
         self.harness.begin_with_initial_hooks()
 
     def test_no_relations(self):
+        # GIVEN no relations joined (see SetUp)
+        # WHEN the charm starts (see SetUp)
+        # THEN status is "active"
+        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+        # AND WHEN "update-status" fires
         self.harness.charm.on.update_status.emit()
+        # THEN status is still "active"
         self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
 
     def test_with_relations(self):
         for incoming, outgoing in [
-            # K8s
             ("logging-provider", "logging-consumer"),
             ("metrics-endpoint", "send-remote-write"),
-            ("grafana-dashboards-provider", "grafana-dashboards-consumer"),
+            ("grafana-dashboards-consumer", "grafana-dashboards-provider"),
         ]:
             with self.subTest(incoming=incoming, outgoing=outgoing):
                 # WHEN an incoming relation is added

--- a/tests/unit/machine/test_relation_status.py
+++ b/tests/unit/machine/test_relation_status.py
@@ -45,7 +45,7 @@ class TestRelationStatus(unittest.TestCase):
         # THEN status is still "active"
         self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
 
-    def test_with_relations(self):
+    def test_cos_agent_with_relations(self):
         # WHEN an incoming relation is added
         rel_id = self.harness.add_relation("cos-agent", "grafana-agent")
         self.harness.add_relation_unit(rel_id, "grafana-agent/0")
@@ -55,6 +55,25 @@ class TestRelationStatus(unittest.TestCase):
 
         # AND WHEN all the necessary outgoing relations are added
         for outgoing in ["send-remote-write", "logging-consumer", "grafana-dashboards-provider"]:
+            # Before the relation is added, the charm is still in blocked status
+            self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
+
+            rel_id = self.harness.add_relation(outgoing, "grafana-agent")
+            self.harness.add_relation_unit(rel_id, "grafana-agent/0")
+
+        # THEN the charm goes into active status
+        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+    def test_juju_info_with_relations(self):
+        # WHEN an incoming relation is added
+        rel_id = self.harness.add_relation("juju-info", "grafana-agent")
+        self.harness.add_relation_unit(rel_id, "grafana-agent/0")
+
+        # THEN the charm goes into blocked status
+        self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
+
+        # AND WHEN all the necessary outgoing relations are added
+        for outgoing in ["send-remote-write", "logging-consumer"]:
             # Before the relation is added, the charm is still in blocked status
             self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 

--- a/tests/unit/machine/test_relation_status.py
+++ b/tests/unit/machine/test_relation_status.py
@@ -1,0 +1,59 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Harness
+
+from charm import GrafanaAgentMachineCharm as GrafanaAgentCharm
+
+
+class TestRelationStatus(unittest.TestCase):
+    def setUp(self, *unused):
+        patcher = patch.object(GrafanaAgentCharm, "_agent_version", property(lambda *_: "0.0.0"))
+        self.mock_version = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        temp_config_path = tempfile.mkdtemp() + "/grafana-agent.yaml"
+        # otherwise will attempt to write to /etc/grafana-agent.yaml
+        patcher = patch("grafana_agent.CONFIG_PATH", temp_config_path)
+        self.config_path_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch("charm.snap")
+        self.mock_snap = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.harness = Harness(GrafanaAgentCharm)
+        self.harness.set_model_name(self.__class__.__name__)
+
+        self.addCleanup(self.harness.cleanup)
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+    def test_no_relations(self):
+        self.harness.charm.on.update_status.emit()
+        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+    def test_with_relations(self):
+        # WHEN an incoming relation is added
+        rel_id = self.harness.add_relation("cos-agent", "grafana-agent")
+        self.harness.add_relation_unit(rel_id, "grafana-agent/0")
+        # self.harness.update_relation_data(rel_id, "grafana-agent/0", {"dummy": "value"})
+
+        # THEN the charm goes into blocked status
+        self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
+
+        # AND WHEN the appropriate outgoing relations are added
+        for outgoing in ["send-remote-write", "logging-consumer", "grafana-dashboards-provider"]:
+            # Before the relation is added, the charm is still in blocked status
+            self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
+
+            rel_id = self.harness.add_relation(outgoing, "grafana-agent")
+            self.harness.add_relation_unit(rel_id, "grafana-agent/0")
+
+        # THEN the charm goes into active status
+        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)

--- a/tests/unit/machine/test_relation_status.py
+++ b/tests/unit/machine/test_relation_status.py
@@ -35,19 +35,25 @@ class TestRelationStatus(unittest.TestCase):
         self.harness.begin_with_initial_hooks()
 
     def test_no_relations(self):
+        # GIVEN no relations joined (see SetUp)
+        # WHEN the charm starts (see SetUp)
+        # THEN status is "active"
+        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+        # AND WHEN "update-status" fires
         self.harness.charm.on.update_status.emit()
+        # THEN status is still "active"
         self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
 
     def test_with_relations(self):
         # WHEN an incoming relation is added
         rel_id = self.harness.add_relation("cos-agent", "grafana-agent")
         self.harness.add_relation_unit(rel_id, "grafana-agent/0")
-        # self.harness.update_relation_data(rel_id, "grafana-agent/0", {"dummy": "value"})
 
         # THEN the charm goes into blocked status
         self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
-        # AND WHEN the appropriate outgoing relations are added
+        # AND WHEN all the necessary outgoing relations are added
         for outgoing in ["send-remote-write", "logging-consumer", "grafana-dashboards-provider"]:
             # Before the relation is added, the charm is still in blocked status
             self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)

--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,7 @@ description = Run unit tests
 deps =
     -r{toxinidir}/requirements.txt
     pytest
+    pytest-subtests
     coverage[toml]
     deepdiff
     fs


### PR DESCRIPTION
## Issue
A WaitingStatus was set only for a scrape - remote-write pair (k8s).
We need to inform the admin of missing relation for all pairs, for both k8s and machine relations.


## Solution
Iterate over all (incoming, outgoing) relation pairs and set to Blocked if an outgoing relation is missing.
Fixes #104.


## Context
NTA.


## Testing Instructions
- Establish "incoming" relations without and "outgoing" pair.
- Incrementally add an "outgoing" relation and see how the status changes.


## Release Notes
Set BlockedStatus per relation.
