### PR TITLE
move on-refresh config to unit databag

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -247,7 +247,7 @@ class COSAgentProvider(Object):
             relations = self._charm.model.relations[self._relation_name]
 
         for relation in relations:
-            if relation.data:
+            if relation.data and self._charm.unit.is_leader():
                 relation.data[self._charm.app].update({"config": self._generate_databag_content()})
 
     def _generate_databag_content(self) -> str:

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -249,8 +249,7 @@ class COSAgentProvider(Object):
         for relation in relations:
             if relation.data:
                 relation.data[self._charm.app].update({"config": self._generate_application_databag_content()})
-                unit = next(iter(relation.units))
-                relation.data[unit].update({"config": self._generate_unit_databag_content()})
+                relation.data[self._charm.unit].update({"config": self._generate_unit_databag_content()})
 
     def _generate_application_databag_content(self) -> str:
         """Collate the data for each nested app databag and return it."""

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -248,7 +248,8 @@ class COSAgentProvider(Object):
 
         for relation in relations:
             if relation.data:
-                relation.data[self._charm.app].update({"config": self._generate_application_databag_content()})
+                if self._charm.unit.is_leader():
+                    relation.data[self._charm.app].update({"config": self._generate_application_databag_content()})
                 relation.data[self._charm.unit].update({"config": self._generate_unit_databag_content()})
 
     def _generate_application_databag_content(self) -> str:

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -262,7 +262,7 @@ class COSAgentProvider(Object):
                 # secondary key
                 "alert_rules": self._metrics_alert_rules,
             },
-            "log": {
+            "logs": {
                 "alert_rules": self._log_alert_rules,
             },
             "dashboards": {

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -171,7 +171,7 @@ from cosl import JujuTopology
 from cosl.rules import AlertRules
 from ops.charm import RelationEvent
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
-from ops.model import Relation
+from ops.model import Relation, Unit
 from ops.testing import CharmType
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
@@ -248,25 +248,42 @@ class COSAgentProvider(Object):
 
         for relation in relations:
             if relation.data:
-                relation.data[self._charm.unit].update({"config": self._generate_databag_content()})
+                relation.data[self._charm.app].update({"config": self._generate_application_databag_content()})
+                unit = next(iter(relation.units))
+                relation.data[unit].update({"config": self._generate_unit_databag_content()})
 
-    def _generate_databag_content(self) -> str:
-        """Collate the data for each nested databag and return it."""
-        # The databag is divided in three chunks: metrics, logs, and dashboards.
+    def _generate_application_databag_content(self) -> str:
+        """Collate the data for each nested app databag and return it."""
+        # The application databag is divided in two chunks: metrics (alert rules only) and dashboards.
+
+        data = {
+            # primary key
+            "metrics": {
+                # secondary key
+                "alert_rules": self._metrics_alert_rules,
+            },
+            "log": {
+                "alert_rules": self._log_alert_rules,
+            },
+            "dashboards": {
+                "dashboards": self._dashboards,
+            },
+        }
+
+        return json.dumps(data)
+
+    def _generate_unit_databag_content(self) -> str:
+        """Collate the data for each nested unit databag and return it."""
+        # The unit databag is divided in two chunks: metrics (scrape jobs only) and logs.
 
         data = {
             # primary key
             "metrics": {
                 # secondary key
                 "scrape_jobs": self._scrape_jobs,
-                "alert_rules": self._metrics_alert_rules,
             },
             "logs": {
                 "targets": self._log_slots,
-                "alert_rules": self._log_alert_rules,
-            },
-            "dashboards": {
-                "dashboards": self._dashboards,
             },
         }
 
@@ -361,6 +378,13 @@ class COSAgentRequirer(Object):
         # FIXME: Figure out what we should do here
         self.on.data_changed.emit()
 
+    @staticmethod
+    def _relation_unit(relation: Relation) -> Optional[Unit]:
+        """Return the principal unit for a relation."""
+        if relation and relation.units:
+            return next(iter(relation.units))
+        return None
+    
     @property
     def _relations(self):
         return self._charm.model.relations[self._relation_name]
@@ -372,7 +396,13 @@ class COSAgentRequirer(Object):
         if not relation.data or not relation.app:
             return None
 
-        config = json.loads(relation.data[relation.app].get("config", "{}"))
+        config = {}
+        if primary_key == "dashboards" or secondary_key == "alert_rules":
+            config = json.loads(relation.data[relation.app].get("config", "{}"))
+        else:
+            unit = COSAgentRequirer._relation_unit(relation)
+            if unit and relation.data[unit]:
+                config = json.loads(relation.data[unit].get("config", "{}"))
         return config.get(primary_key, {}).get(secondary_key, None)
 
     @property
@@ -380,6 +410,7 @@ class COSAgentRequirer(Object):
         """Fetch metrics alerts."""
         alert_rules = {}
         for relation in self._relations:
+            unit = self._relation_unit(relation)
             # This is only used for naming the file, so be as specific as we
             # can be, but it's ok if the unit name isn't exactly correct, so
             # long as we don't dedupe away the alerts, which will be
@@ -387,7 +418,7 @@ class COSAgentRequirer(Object):
                 model=self._charm.model.name,
                 model_uuid=self._charm.model.uuid,
                 application=relation.app.name if relation.app else "unknown",
-                unit=self._charm.unit.name,
+                unit=unit.name if unit else "unknown",
             ).identifier
             if data := self._fetch_data_from_relation(relation, "metrics", "alert_rules"):
                 alert_rules.update({identifier: data})

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -176,7 +176,7 @@ from ops.testing import CharmType
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 2
+LIBPATCH = 3
 
 PYDEPS = ["cosl"]
 
@@ -247,8 +247,8 @@ class COSAgentProvider(Object):
             relations = self._charm.model.relations[self._relation_name]
 
         for relation in relations:
-            if relation.data and self._charm.unit.is_leader():
-                relation.data[self._charm.app].update({"config": self._generate_databag_content()})
+            if relation.data:
+                relation.data[self._charm.unit].update({"config": self._generate_databag_content()})
 
     def _generate_databag_content(self) -> str:
         """Collate the data for each nested databag and return it."""


### PR DESCRIPTION
## Issue
Closes #140.


## Solution
Move the config information to the unit databag instead of the application one.


## Testing Instructions
Pack this charm, add this library to the Kafka charm and pack it; scale up Kafka and then set up the `cos-agent` relation, then relating the agent to Prometheus. Verify that metrics for all units are in Prometheus.