### PR TITLE
use better locations for the positions files

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -216,6 +216,10 @@ class GrafanaAgentCharm(CharmBase):
         """Return a list of dashboards."""
         raise NotImplementedError("Please override the dashboards method")
 
+    def positions_dir(self) -> str:
+        """Return the correct positions directory."""
+        raise NotImplementedError("Please override the positions_dir method")
+
     # End: Abstract Methods
 
     def _update_metrics_alerts(self):
@@ -510,7 +514,7 @@ class GrafanaAgentCharm(CharmBase):
         configs.extend(self._additional_log_configs)  # type: ignore
         return (
             {
-                "positions_directory": "/tmp/grafana-agent-positions",
+                "positions_directory": f"{self.positions_dir()}/grafana-agent-positions",
                 "configs": configs,
             }
             if configs

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -146,6 +146,10 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         """Restart grafana agent."""
         self._container.restart("agent")
 
+    def positions_dir(self) -> str:
+        """Return the correct positions directory."""
+        return "/run"
+
 
 if __name__ == "__main__":
     main(GrafanaAgentK8sCharm)

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -464,6 +464,10 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                 logger.error(f"error connecting plug {plug} to grafana-agent:logs")
                 logger.error(e.message)
 
+    def positions_dir(self) -> str:
+        """Return the correct positions directory."""
+        return "${SNAP_DATA}"
+
 
 if __name__ == "__main__":
     main(GrafanaAgentMachineCharm)

--- a/tests/unit/k8s/test_scrape_configuration.py
+++ b/tests/unit/k8s/test_scrape_configuration.py
@@ -299,7 +299,7 @@ class TestScrapeConfiguration(unittest.TestCase):
                     ],
                 },
             ],
-            "positions_directory": "/tmp/grafana-agent-positions",
+            "positions_directory": "/run/grafana-agent-positions",
         }
         self.assertEqual(
             DeepDiff(expected, self.harness.charm._loki_config, ignore_order=True), {}


### PR DESCRIPTION
## Issue
#131

## Solution
Each charm class defines a `positions_dir` method to be called by the parent.


## Testing Instructions
Deploy on k8s and machine models and check that the positions files are in the correct place.


## Release Notes
Fixed a bug where grafana-agent-k8s was not storing position files correctly.
