### PR TITLE
(cos-agent) Use peer relation data for communicating all principals' data (WIP)

### DIFF
--- a/machine_metadata.yaml
+++ b/machine_metadata.yaml
@@ -53,3 +53,7 @@ requires:
 provides:
   grafana-dashboards-provider:
     interface: grafana_dashboard
+
+peers:
+  cluster:
+    interface: grafana_agent_replica


### PR DESCRIPTION
## Issue
Subordinate charms only see one unit over the subordinated relation - the principal unit. I.e. subordinate units cannot iterate over relation data from other units.
Combined with a leader guard, this means only one principal unit can get its files across - the one that is related to the subordinate leader.


## Solution
- [x] Provider: copy data from principal to peer unit data
- [ ] Requirer: refactor `_fetch_data_from_relation`

Fixes #158.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
1. Check out https://github.com/canonical/zookeeper-operator/pull/56 and copy over the `cos-agent` lib from this PR.
2. Pack zookeeper.
3. Deploy `first-zk` (two units), `second-zk` (one unit is enough) and gagent from this PR.
4. Relate both Zks to cgagent over cos-agent.
5. `juju show-unit ...`
6. Good luck.


## Release Notes
Use peer relation data for communicating all principals' data.
