### PR TITLE
fix log directory traversal for machine charm

### DIFF
--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -421,9 +421,9 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         for endpoint in self._cos.snap_log_endpoints:
             fstab_entry = agent_fstab.entry(endpoint.owner, endpoint.name)
             target_path = (
-                f"{fstab_entry.target}/*"
+                f"{fstab_entry.target}/**"
                 if fstab_entry
-                else "/snap/grafana-agent/current/shared-logs/**/*"
+                else "/snap/grafana-agent/current/shared-logs/**"
             )
             job = {
                 "job_name": endpoint.owner,
@@ -440,6 +440,11 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                             },
                         },
                     }
+                ],
+                "pipeline_stages": [
+                    {
+                        "drop": {"source": "error", "value": "file is a directory"},
+                    },
                 ],
             }
 

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -443,7 +443,11 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                 ],
                 "pipeline_stages": [
                     {
-                        "drop": {"source": "error", "value": "file is a directory"},
+                        "drop": {
+                            "source": ["level", "msg"],
+                            "separator": "#",
+                            "expression": "failed to tail file#file is a directory",
+                        },
                     },
                 ],
             }


### PR DESCRIPTION
## Issue
Closes #163.


## Solution
The `__path__` of the log files can be a glob; however, the globbing library will always include both files and directories. `**` alone will include the files (which is the desired behavior), but won't remove the `file is directory` errors.  
Thus, a [drop pipeline](https://grafana.com/docs/loki/latest/clients/promtail/stages/drop/) is added to drop those messages specifically from the data flow.


## Testing Instructions
Deploy according to the issue description and verify those messages don't appear anymore.


## Release Notes
Correctly traverse log directories for the machine charm.
