### PR TITLE
use ruff instead of flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,26 +13,25 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107", "RET504"]
+
+[tool.ruff.per-file-ignores]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,C901", "lib/*:C901"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+"tests/*" = ["D100","D101","D102","D103","C901"]
+"lib/*" = ["C901"]
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 # Static analysis tools configuration
 [tool.mypy]

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -279,8 +279,7 @@ class GrafanaAgentCharm(CharmBase):
         """Recurse through wrappers until we find a real object, not a Callable."""
         if callable(maybe_func):
             return self._recurse_call_chain(maybe_func())
-        else:
-            return maybe_func
+        return maybe_func
 
     def update_alerts_rules(self, alerts_func: Any, reload_func: Callable, mapping: RulesMapping):
         """Copy alert rules from relations and save them to disk."""
@@ -357,7 +356,7 @@ class GrafanaAgentCharm(CharmBase):
                 continue
 
             has_outgoing = any(
-                map(lambda outgoing: len(self.model.relations.get(outgoing, [])), outgoings)
+                (len(self.model.relations.get(outgoing, [])) for outgoing in outgoings)
             )
             if not has_outgoing:
                 missing = "|".join(outgoings)
@@ -597,7 +596,7 @@ class GrafanaAgentCharm(CharmBase):
     @property
     def _instance_name(self) -> str:
         """Return the instance name as interpolated topology values."""
-        return "_".join([v for v in self._instance_topology.values()])
+        return "_".join(list(self._instance_topology.values()))
 
     def _reload_config(self, attempts: int = 10) -> None:
         """Reload the config file.

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -15,9 +15,8 @@ from charms.observability_libs.v1.kubernetes_service_patch import (
     ServicePort,
 )
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
-from ops.main import main
-
 from grafana_agent import CONFIG_PATH, GrafanaAgentCharm
+from ops.main import main
 
 logger = logging.getLogger(__name__)
 

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -13,10 +13,9 @@ from typing import Any, Dict, List, Optional, Union
 
 from charms.grafana_agent.v0.cos_agent import COSAgentRequirer
 from charms.operator_libs_linux.v1 import snap  # type: ignore
+from grafana_agent import GrafanaAgentCharm
 from ops.main import main
 from ops.model import MaintenanceStatus, Relation, Unit
-
-from grafana_agent import GrafanaAgentCharm
 
 logger = logging.getLogger(__name__)
 
@@ -376,8 +375,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                 "juju_application": unit.app.name,
                 "juju_unit": unit.name,
             }
-        else:
-            return {}
+        return {}
 
     @property
     def _principal_labels(self) -> Dict[str, str]:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -229,7 +229,9 @@ async def get_grafana_dashboards(ops_test: OpsTest, app_name: str, unit_num: int
     look through a query and fetch them.
 
     Args:
+        ops_test: pytest-operator plugin
         app_name: string name of Grafana application
+        unit_num: integer number of a Grafana juju unit
 
     Returns:
         a list of dashboards

--- a/tests/scenario/test_machine_charm/test_cos_agent_e2e.py
+++ b/tests/scenario/test_machine_charm/test_cos_agent_e2e.py
@@ -8,11 +8,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from charms.grafana_agent.v0.cos_agent import CosAgentPeersUnitData, COSAgentProvider
+from machine_charm import GrafanaAgentMachineCharm
 from ops.charm import CharmBase
 from ops.framework import Framework
 from scenario import PeerRelation, Relation, State, SubordinateRelation
-
-from machine_charm import GrafanaAgentMachineCharm
 
 
 @pytest.fixture

--- a/tests/scenario/test_machine_charm/test_scrape_configs.py
+++ b/tests/scenario/test_machine_charm/test_scrape_configs.py
@@ -9,11 +9,10 @@ import uuid
 from pathlib import Path
 from unittest.mock import patch
 
+import machine_charm
 import yaml
 from charms.grafana_agent.v0.cos_agent import CosAgentProviderUnitData
 from scenario import Model, PeerRelation, Relation, State, SubordinateRelation
-
-import machine_charm
 
 machine_meta = yaml.safe_load(
     (

--- a/tests/scenario/test_start_statuses.py
+++ b/tests/scenario/test_start_statuses.py
@@ -7,14 +7,13 @@ from pathlib import Path
 from typing import Type
 from unittest.mock import patch
 
+import k8s_charm
+import machine_charm
 import pytest
 import yaml
 from ops import pebble
 from ops.testing import CharmType
 from scenario import Container, ExecOutput, State, SubordinateRelation
-
-import k8s_charm
-import machine_charm
 
 CHARM_ROOT = Path(__file__).parent.parent.parent
 

--- a/tests/unit/machine/test_fstab_parsing.py
+++ b/tests/unit/machine/test_fstab_parsing.py
@@ -4,7 +4,6 @@ import unittest
 from pathlib import Path
 
 from fs.tempfs import TempFS
-
 from machine_charm import SnapFstab
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,9 @@ skip_install=True
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:render-k8s]
@@ -60,20 +60,11 @@ skip_install=True
 description = Check code against coding style standards
 deps =
     black
-    flake8 < 5
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache --skip *.svg
-
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib}]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being one new rule being ignored (which wasn't checked before anyway):
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.