### PR TITLE
fix crashes from log glob change

### DIFF
--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -323,6 +323,13 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                 "scrape_configs": [
                     {
                         "job_name": "varlog",
+                        "pipeline_stages": [
+                            {
+                                "drop": {
+                                    "expression": ".*file is a directory.*",
+                                },
+                            },
+                        ],
                         "static_configs": [
                             {
                                 "targets": ["localhost"],
@@ -333,7 +340,17 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                             }
                         ],
                     },
-                    {"job_name": "syslog", "journal": {"labels": self._principal_labels}},
+                    {
+                        "job_name": "syslog",
+                        "journal": {"labels": self._principal_labels},
+                        "pipeline_stages": [
+                            {
+                                "drop": {
+                                    "expression": ".*file is a directory.*",
+                                },
+                            },
+                        ],
+                    },
                 ]
                 + self._snap_plugs_logging_configs,
             }
@@ -442,9 +459,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                 "pipeline_stages": [
                     {
                         "drop": {
-                            "source": ["level", "msg"],
-                            "separator": "#",
-                            "expression": "failed to tail file#file is a directory",
+                            "expression": ".*file is a directory.*",
                         },
                     },
                 ],

--- a/tests/scenario/test_machine_charm/test_scrape_configs.py
+++ b/tests/scenario/test_machine_charm/test_scrape_configs.py
@@ -181,6 +181,9 @@ def test_snap_endpoints():
                     "scrape_configs": [
                         {
                             "job_name": "varlog",
+                            "pipeline_stages": [
+                                {"drop": {"expression": ".*file is a directory.*"}}
+                            ],
                             "static_configs": [
                                 {
                                     "labels": {
@@ -197,6 +200,9 @@ def test_snap_endpoints():
                         },
                         {
                             "job_name": "syslog",
+                            "pipeline_stages": [
+                                {"drop": {"expression": ".*file is a directory.*"}}
+                            ],
                             "journal": {
                                 "labels": {
                                     "instance": f"my-model_{my_uuid}_principal_principal/0",
@@ -209,6 +215,9 @@ def test_snap_endpoints():
                         },
                         {
                             "job_name": "foo",
+                            "pipeline_stages": [
+                                {"drop": {"expression": ".*file is a directory.*"}}
+                            ],
                             "static_configs": [
                                 {
                                     "labels": {
@@ -220,18 +229,12 @@ def test_snap_endpoints():
                                     "targets": ["localhost"],
                                 }
                             ],
-                            "pipeline_stages": [
-                                {
-                                    "drop": {
-                                        "expression": "failed to tail file#file is a directory",
-                                        "separator": "#",
-                                        "source": ["level", "msg"],
-                                    }
-                                }
-                            ],
                         },
                         {
                             "job_name": "oh",
+                            "pipeline_stages": [
+                                {"drop": {"expression": ".*file is a directory.*"}}
+                            ],
                             "static_configs": [
                                 {
                                     "labels": {
@@ -241,15 +244,6 @@ def test_snap_endpoints():
                                         "juju_model_uuid": my_uuid,
                                     },
                                     "targets": ["localhost"],
-                                }
-                            ],
-                            "pipeline_stages": [
-                                {
-                                    "drop": {
-                                        "expression": "failed to tail file#file is a directory",
-                                        "separator": "#",
-                                        "source": ["level", "msg"],
-                                    }
                                 }
                             ],
                         },


### PR DESCRIPTION
## Issue
After tackling #163 with #175, the Grafana Agent snap started crashing. Turns out that the specified pipeline stage is causing the issue:
```
Apr 28 10:12:13 juju-5a1d83-0 grafana-agent.grafana-agent[15458]: ts=2023-04-28T10:12:13.077284721Z caller=main.go:64 level=error msg="error creating the agent server entrypoint" err="unable to apply config for log_file_scraper: unable to create logs instance: failed to make file target manager: invalid drop stage config: 1 error(s) decoding:\n\n* 'source' expected type 'string', got unconvertible type '[]interface {}', value: '[level msg]'"
```

Regardless of the pipeline stage [documentation](https://grafana.com/docs/loki/latest/clients/promtail/stages/drop/) specifying it does accept a list of values, the agent doesn't take it.

## Solution
Remove the `source` selector; the `expression` will match against the whole log line, achieving the same effect. The change has also been applied to the other scrape jobs which would otherwise report the same message.
