### PR TITLE
Add more alert rules for memory

### DIFF
--- a/src/prometheus_alert_rules/memory.rules
+++ b/src/prometheus_alert_rules/memory.rules
@@ -20,7 +20,10 @@ groups:
         ) / node_memory_SwapTotal_bytes
       ))
   - alert: HostMemoryFillsUp
-    expr: predict_linear(node_memory_MemUsed_percentage[30m], 5*60) >= 90
+    expr: |
+      predict_linear(node_memory_MemUsed_percentage[30m], 5*60) >= 90
+      and
+      avg_over_time(node_memory_MemUsed_percentage[2m]) < 90
     for: 2m
     labels:
       severity: warning

--- a/src/prometheus_alert_rules/memory.rules
+++ b/src/prometheus_alert_rules/memory.rules
@@ -1,0 +1,69 @@
+groups:
+- name: HostMemory
+  rules:
+  - record: node_memory_MemUsed_percentage
+    expr: |
+      100 * (1 - (
+        (
+          node_memory_MemFree_bytes
+          + node_memory_Cached_bytes
+          + node_memory_Buffers_bytes
+          + node_memory_SReclaimable_bytes
+        ) / node_memory_MemTotal_bytes
+      ))
+  - record: node_memory_SwapUsed_percentage
+    expr: |
+      100 * (1 - (
+        (
+          node_memory_SwapFree_bytes
+          + node_memory_SwapCached_bytes
+        ) / node_memory_SwapTotal_bytes
+      ))
+  - alert: HostMemoryFillsUp
+    expr: predict_linear(node_memory_MemUsed_percentage[30m], 5*60) >= 90
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "[Prediction] Host memory usage will increase to 90% in the near future (instance {{ $labels.instance }})"
+      description: >-
+        Host can potentially reach 90% memory utilization and risk an OOM kill.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+        The 5-minute-ahead prediction is made as a linear regression from the last 30 minutes of data.
+  - alert: HostMemoryFull
+    expr: avg_over_time(node_memory_MemUsed_percentage[1m]) > 95
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      summary: Host memory usage reached 95% load (instance {{ $labels.instance }})
+      description: >-
+        Host memory usage reached 95%
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+  - alert: HostSwapFull
+    expr: |
+      avg_over_time(node_memory_MemUsed_percentage[1m]) > 90
+      and
+      avg_over_time(node_memory_SwapUsed_percentage[1m]) > 50
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      summary: Host memory and swap usage reached 90% and 50% load (instance {{ $labels.instance }})
+      description: >-
+        Host memory and swap usage reached 90% and 50% load
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+  - alert: HostMemoryUnderMemoryPressure
+    expr: rate(node_vmstat_pgmajfault[1m]) > 1000
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: Host memory under memory pressure (instance {{ $labels.instance }})
+      description: >-
+        The node is under heavy memory pressure. High rate of major page faults.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/memory.rules
+++ b/src/prometheus_alert_rules/memory.rules
@@ -25,9 +25,9 @@ groups:
     labels:
       severity: warning
     annotations:
-      summary: "[Prediction] Host memory usage will increase to 90% in the near future (instance {{ $labels.instance }})"
+      summary: '[Prediction] Host memory usage will increase to {{ $value | printf "%.0f" }}% in the near future (instance {{ $labels.instance }})'
       description: >-
-        Host can potentially reach 90% memory utilization and risk an OOM kill.
+        Host can potentially reach {{ $value | printf "%.0f" }}% memory utilization and risk an OOM kill.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
         The 5-minute-ahead prediction is made as a linear regression from the last 30 minutes of data.
@@ -37,9 +37,9 @@ groups:
     labels:
       severity: critical
     annotations:
-      summary: Host memory usage reached 95% load (instance {{ $labels.instance }})
+      summary: Host memory usage reached {{ $value | printf "%.0f" }}% load (instance {{ $labels.instance }})
       description: >-
-        Host memory usage reached 95%
+        Host memory usage reached {{ $value | printf "%.0f" }}%
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
   - alert: HostSwapFull

--- a/src/prometheus_alert_rules/memory_pressure.rule
+++ b/src/prometheus_alert_rules/memory_pressure.rule
@@ -1,8 +1,0 @@
-alert: HostMemoryUnderMemoryPressure
-expr: rate(node_vmstat_pgmajfault[1m]) > 1000
-for: 2m
-labels:
-  severity: warning
-annotations:
-  summary: Host memory under memory pressure (instance {{ $labels.instance }})
-  description: "The node is under heavy memory pressure. High rate of major page faults\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"


### PR DESCRIPTION
- add alert for memory prediction reaching threshold
- add alert for memory reaching threshold
- add alert for swap reaching threshold

## Context
Moving memory NRPE checks from [charm-nrpe](https://git.launchpad.net/charm-nrpe/tree/files/plugins).


## Testing Instructions
Tested with
```yaml
rule_files:
  - memory.rules

evaluation_interval: 1m

tests:
  - interval: 1m
    input_series:
      - series: 'node_memory_MemFree_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '450 380 250 92 50 31 29 5 5 5 48 150 380 450 450'
      - series: 'node_memory_Cached_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '0x15'
      - series: 'node_memory_Buffers_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '0x15'
      - series: 'node_memory_SReclaimable_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '0x15'
      - series: 'node_memory_MemTotal_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '512x15'
      - series: 'node_memory_SwapFree_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '128x5 40 40 40 40 40 128x5'
      - series: 'node_memory_SwapCached_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '0x15'
      - series: 'node_memory_SwapTotal_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '128x15'
    promql_expr_test:
      - expr: node_memory_MemUsed_percentage
        eval_time: 4m
        exp_samples:
          - labels: 'node_memory_MemUsed_percentage{instance="test-model_1234_test-app_test-app/0"}'
            value: 90.234375
      - expr: node_memory_MemUsed_percentage
        eval_time: 5m
        exp_samples:
          - labels: 'node_memory_MemUsed_percentage{instance="test-model_1234_test-app_test-app/0"}'
            value: 93.9453125
      - expr: node_memory_MemUsed_percentage
        eval_time: 6m
        exp_samples:
           - labels: 'node_memory_MemUsed_percentage{instance="test-model_1234_test-app_test-app/0"}'
             value: 94.3359375
      - expr: node_memory_MemUsed_percentage
        eval_time: 7m
        exp_samples:
           - labels: 'node_memory_MemUsed_percentage{instance="test-model_1234_test-app_test-app/0"}'
             value: 99.0234375
      - expr: node_memory_MemUsed_percentage
        eval_time: 8m
        exp_samples:
           - labels: 'node_memory_MemUsed_percentage{instance="test-model_1234_test-app_test-app/0"}'
             value: 99.0234375
      - expr: avg_over_time(node_memory_MemUsed_percentage[1m])
        eval_time: 4m
        exp_samples:
           - labels: '{instance="test-model_1234_test-app_test-app/0"}'
             value: 86.1328125
      - expr: avg_over_time(node_memory_MemUsed_percentage[1m])
        eval_time: 5m
        exp_samples:
           - labels: '{instance="test-model_1234_test-app_test-app/0"}'
             value: 92.08984375
      - expr: avg_over_time(node_memory_MemUsed_percentage[1m])
        eval_time: 6m
        exp_samples:
           - labels: '{instance="test-model_1234_test-app_test-app/0"}'
             value: 94.140625
      - expr: avg_over_time(node_memory_MemUsed_percentage[1m])
        eval_time: 7m
        exp_samples:
           - labels: '{instance="test-model_1234_test-app_test-app/0"}'
             value: 96.6796875
      - expr: avg_over_time(node_memory_MemUsed_percentage[1m])
        eval_time: 8m
        exp_samples:
           - labels: '{instance="test-model_1234_test-app_test-app/0"}'
             value: 99.0234375
      - expr: avg_over_time(node_memory_MemUsed_percentage[1m])
        eval_time: 9m
        exp_samples:
           - labels: '{instance="test-model_1234_test-app_test-app/0"}'
             value: 99.0234375
      - expr: avg_over_time(node_memory_SwapUsed_percentage[1m])
        eval_time: 8m
        exp_samples:
           - labels: '{instance="test-model_1234_test-app_test-app/0"}'
             value: 68.75
      - expr: avg_over_time(node_memory_SwapUsed_percentage[1m])
        eval_time: 9m
        exp_samples:
           - labels: '{instance="test-model_1234_test-app_test-app/0"}'
             value: 68.75
    alert_rule_test:
      - eval_time: 9m
        alertname: HostMemoryFull
        exp_alerts:
          - exp_labels:
              severity: critical
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: "Host memory usage reached 99% load (instance test-model_1234_test-app_test-app/0)"
              description: >-
                Host memory usage reached 99%
                  VALUE = 99.0234375
                  LABELS = map[instance:test-model_1234_test-app_test-app/0]
      - eval_time: 9m
        alertname: HostSwapFull
        exp_alerts:
          - exp_labels:
              severity: critical
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: "Host memory and swap usage reached 90% and 50% load (instance test-model_1234_test-app_test-app/0)"
              description: >-
                Host memory and swap usage reached 90% and 50% load
                  VALUE = 99.0234375
                  LABELS = map[instance:test-model_1234_test-app_test-app/0]

  # test for prediction of memory usage
  - interval: 1m
    input_series:
      - series: 'node_memory_MemFree_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '95-2.5x36 5x24'
      - series: 'node_memory_Cached_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '0x60'
      - series: 'node_memory_Buffers_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '0x60'
      - series: 'node_memory_SReclaimable_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '0x60'
      - series: 'node_memory_MemTotal_bytes{instance="test-model_1234_test-app_test-app/0"}'
        values: '100x60'
    promql_expr_test:
      - expr: node_memory_MemUsed_percentage
        eval_time: 30m  # 95 - 75 = 20
        exp_samples:
          - labels: 'node_memory_MemUsed_percentage{instance="test-model_1234_test-app_test-app/0"}'
            value: 80
      - expr: node_memory_MemUsed_percentage
        eval_time: 34m  # 95 - 85 = 10
        exp_samples:
          - labels: 'node_memory_MemUsed_percentage{instance="test-model_1234_test-app_test-app/0"}'
            value: 90
      - expr: node_memory_MemUsed_percentage
        eval_time: 36m  # 95 - 90 = 5
        exp_samples:
          - labels: 'node_memory_MemUsed_percentage{instance="test-model_1234_test-app_test-app/0"}'
            value: 95
      - expr: predict_linear(node_memory_MemUsed_percentage[30m], 5*60)
        eval_time: 30m
        exp_samples:
          - labels: '{instance="test-model_1234_test-app_test-app/0"}'
            value: 92.5
      - expr: predict_linear(node_memory_MemUsed_percentage[30m], 5*60)
        eval_time: 31m
        exp_samples:
          - labels: '{instance="test-model_1234_test-app_test-app/0"}'
            value: 95
      - expr: predict_linear(node_memory_MemUsed_percentage[30m], 5*60)
        eval_time: 32m
        exp_samples:
          - labels: '{instance="test-model_1234_test-app_test-app/0"}'
            value: 97.5
    alert_rule_test:
      - eval_time: 30m
        alertname: HostMemoryFillsUp
        exp_alerts: []  # no alert
      - eval_time: 31m
        alertname: HostMemoryFillsUp
        exp_alerts:
          - exp_labels:
              severity: warning
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: "[Prediction] Host memory usage will increase to 95% in the near future (instance test-model_1234_test-app_test-app/0)"
              description: >-
                Host can potentially reach 95% memory utilization and risk an OOM kill.
                  VALUE = 95
                  LABELS = map[instance:test-model_1234_test-app_test-app/0]
                The 5-minute-ahead prediction is made as a linear regression from the last 30 minutes of data.
      - eval_time: 32m
        alertname: HostMemoryFillsUp
        exp_alerts:
          - exp_labels:
              severity: warning
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: "[Prediction] Host memory usage will increase to 98% in the near future (instance test-model_1234_test-app_test-app/0)"
              description: >-
                Host can potentially reach 98% memory utilization and risk an OOM kill.
                  VALUE = 97.5
                  LABELS = map[instance:test-model_1234_test-app_test-app/0]
                The 5-minute-ahead prediction is made as a linear regression from the last 30 minutes of data.
      - eval_time: 33m
        alertname: HostMemoryFillsUp
        exp_alerts:
          - exp_labels:
              severity: warning
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: "[Prediction] Host memory usage will increase to 100% in the near future (instance test-model_1234_test-app_test-app/0)"
              description: >-
                Host can potentially reach 100% memory utilization and risk an OOM kill.
                  VALUE = 100
                  LABELS = map[instance:test-model_1234_test-app_test-app/0]
                The 5-minute-ahead prediction is made as a linear regression from the last 30 minutes of data.
      - eval_time: 34m
        alertname: HostMemoryFillsUp
        exp_alerts:
          - exp_labels:
              severity: warning
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: "[Prediction] Host memory usage will increase to 102% in the near future (instance test-model_1234_test-app_test-app/0)"
              description: >-
                Host can potentially reach 102% memory utilization and risk an OOM kill.
                  VALUE = 102.5
                  LABELS = map[instance:test-model_1234_test-app_test-app/0]
                The 5-minute-ahead prediction is made as a linear regression from the last 30 minutes of data.
      - eval_time: 35m
        alertname: HostMemoryFillsUp
        exp_alerts: []  # no alert
      - eval_time: 40m
        alertname: HostMemoryFillsUp
        exp_alerts: []  # no alert during stable high memory load

  - interval: 1m
    input_series:
      - series: 'node_vmstat_pgmajfault{instance="test-model_1234_test-app_test-app/0"}'
        values: '50000+75000x10'
    alert_rule_test:
      - eval_time: 5m
        alertname: HostMemoryUnderMemoryPressure
        exp_alerts:
          - exp_labels:
              severity: warning
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Host memory under memory pressure (instance test-model_1234_test-app_test-app/0)
              description: >-
                The node is under heavy memory pressure. High rate of major page faults.
                  VALUE = 1250
                  LABELS = map[instance:test-model_1234_test-app_test-app/0]
```
and promtool
```bash
x1:➜  prometheus_alert_rules git:(nrpe/memory-aler-rules) ✗ promtool test rules ./test_memory.yaml
Unit Testing:  ./test_memory.yaml
  SUCCESS
                                                                                                  [0.13s]
```


## Release Notes
- add alert for memory prediction reaching threshold
- add alert for memory reaching threshold
- add alert for swap reaching threshold
