### PR TITLE
Add alert rules for network

### DIFF
--- a/src/prometheus_alert_rules/.wokeignore
+++ b/src/prometheus_alert_rules/.wokeignore
@@ -1,0 +1,1 @@
+network.rules

--- a/src/prometheus_alert_rules/network.rules
+++ b/src/prometheus_alert_rules/network.rules
@@ -23,17 +23,6 @@ groups:
         Interface '{{ $labels.device }}' speed changed to {{ $value }}B/s on host {{ $labels.instance }}.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
-  - alert: HostInterfaceDown
-    expr: node_network_up{device!~"lo"} == 0
-    for: 2m
-    labels:
-      severity: warning
-    annotations:
-      summary: Interface '{{ $labels.device }}' is down (instance {{ $labels.instance }})
-      description: >-
-        Interface '{{ $labels.device }}' is down on host {{ $labels.instance }}.
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}
   - alert: HostNetworkReceiveErrors
     expr: rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01
     for: 2m

--- a/src/prometheus_alert_rules/network.rules
+++ b/src/prometheus_alert_rules/network.rules
@@ -1,0 +1,58 @@
+groups:
+- name: HostNetwork
+  rules:
+  - alert: HostInterfaceMTUSize
+    expr: last_over_time(node_network_mtu_bytes[30m]) and changes(node_network_mtu_bytes[30m]) > 0
+    for: 0m
+    labels:
+      severity: warning
+    annotations:
+      summary: Interface '{{ $labels.device }}' MTU size changed (instance {{ $labels.instance }})
+      description: >-
+        Interface '{{ $labels.device }}' MTU size changed to {{ $value }} on host {{ $labels.instance }}.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+  - alert: HostInterfaceSpeed
+    expr: last_over_time(node_network_speed_bytes[30m]) and changes(node_network_speed_bytes[30m]) > 0
+    for: 0m
+    labels:
+      severity: warning
+    annotations:
+      summary: Interface '{{ $labels.device }}' speed changed (instance {{ $labels.instance }})
+      description: >-
+        Interface '{{ $labels.device }}' speed changed to {{ $value }}B/s on host {{ $labels.instance }}.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+  - alert: HostInterfaceDown
+    expr: node_network_up{device!~"lo"} == 0
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: Interface '{{ $labels.device }}' is down (instance {{ $labels.instance }})
+      description: >-
+        Interface '{{ $labels.device }}' is down on host {{ $labels.instance }}.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+  - alert: HostNetworkReceiveErrors
+    expr: rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: Interface '{{ $labels.device }}' network receive to many errors (instance {{ $labels.instance }})
+      description: >-
+        Interface '{{ $labels.device }}' has encountered {{ $value | printf "%.4f" }}% receive errors in the last two minutes on host {{ $labels.instance }}.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+  - alert: HostNetworkTransmitErrors
+    expr: rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: Interface '{{ $labels.device }}' network transmit to many errors (instance {{ $labels.instance }})
+      description: >-
+        Interface '{{ $labels.device }}' has encountered {{ $value | printf "%.4f" }}% transmit errors in the last two minutes on host {{ $labels.instance }}.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/network.rules
+++ b/src/prometheus_alert_rules/network.rules
@@ -56,3 +56,14 @@ groups:
         Interface '{{ $labels.device }}' has encountered {{ $value | printf "%.4f" }}% transmit errors in the last two minutes on host {{ $labels.instance }}.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
+  - alert: HostNetworkBondDegraded
+    expr: (node_bonding_active - node_bonding_slaves) != 0
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: Host bond network is degraded (instance {{ $labels.instance }})
+      description: >-
+        Host bond `{{ $labels.master }}` network is degraded.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}


### PR DESCRIPTION
- add alert rule for interface MTU size change
- add alert rule for interface speed change
- add alert rule for interface DOWN
- add alert rule for high network receive/transmit errors
- add alert rule for bond degradation

## Context
Moving network NRPE checks from [charm-nrpe](https://git.launchpad.net/charm-nrpe/tree/files/plugins).


## Testing Instructions
Tested with
```yaml
rule_files:
  - network.rules

evaluation_interval: 1m

tests:
  - interval: 1m
    input_series:
      - series: 'node_network_mtu_bytes{instance="test-model_1234_test-app_test-app/0", device="eth0"}'
        values: '9000x29 1500 9000x180'
      - series: 'node_network_mtu_bytes{instance="test-model_1234_test-app_test-app/0", device="eth1"}'
        values: '1500x240'
    alert_rule_test:
      - eval_time: 29m
        alertname: HostInterfaceMTUSize
        exp_alerts: []  # no alert
      - eval_time: 30m
        alertname: HostInterfaceMTUSize
        exp_alerts:
          - exp_labels:
              severity: warning
              device: eth0
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Interface 'eth0' MTU size changed (instance test-model_1234_test-app_test-app/0)
              description: >-
                Interface 'eth0' MTU size changed to 1500 on host test-model_1234_test-app_test-app/0.
                  VALUE = 1500
                  LABELS = map[__name__:node_network_mtu_bytes device:eth0 instance:test-model_1234_test-app_test-app/0]
      - eval_time: 61m
        alertname: HostInterfaceMTUSize
        exp_alerts: []  # no alert

  - interval: 1m
    input_series:
      - series: 'node_network_speed_bytes{instance="test-model_1234_test-app_test-app/0", device="eth0"}'
        values: '1000x29 100 1000x180'
      - series: 'node_network_speed_bytes{instance="test-model_1234_test-app_test-app/0", device="eth1"}'
        values: '1000x240'
    alert_rule_test:
      - eval_time: 29m
        alertname: HostInterfaceSpeed
        exp_alerts: []  # no alert
      - eval_time: 30m
        alertname: HostInterfaceSpeed
        exp_alerts:
          - exp_labels:
              severity: warning
              device: eth0
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Interface 'eth0' speed changed (instance test-model_1234_test-app_test-app/0)
              description: >-
                Interface 'eth0' speed changed to 100B/s on host test-model_1234_test-app_test-app/0.
                  VALUE = 100
                  LABELS = map[__name__:node_network_speed_bytes device:eth0 instance:test-model_1234_test-app_test-app/0]
      - eval_time: 61m
        alertname: HostInterfaceSpeed
        exp_alerts: []  # no alert

  - interval: 1m
    input_series:
      - series: 'node_network_up{instance="test-model_1234_test-app_test-app/0", device="eth0"}'
        values: '1 0 0 0 1'
      - series: 'node_network_up{instance="test-model_1234_test-app_test-app/0", device="eth1"}'
        values: '1 0 0 0 1'
      - series: 'node_network_up{instance="test-model_1234_test-app_test-app/0", device="lo"}'
        values: '0 0 0 0 0'
    alert_rule_test:
      - eval_time: 0m
        alertname: HostInterfaceDown
        exp_alerts: []  # no alert
      - eval_time: 3m
        alertname: HostInterfaceDown
        exp_alerts:
          - exp_labels:
              severity: warning
              device: eth0
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Interface 'eth0' is down (instance test-model_1234_test-app_test-app/0)
              description: >-
                Interface 'eth0' is down on host test-model_1234_test-app_test-app/0.
                  VALUE = 0
                  LABELS = map[__name__:node_network_up device:eth0 instance:test-model_1234_test-app_test-app/0]
          - exp_labels:
              severity: warning
              device: eth1
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Interface 'eth1' is down (instance test-model_1234_test-app_test-app/0)
              description: >-
                Interface 'eth1' is down on host test-model_1234_test-app_test-app/0.
                  VALUE = 0
                  LABELS = map[__name__:node_network_up device:eth1 instance:test-model_1234_test-app_test-app/0]
      - eval_time: 5m
        alertname: HostInterfaceDown
        exp_alerts: []  # no alert

  - interval: 1m
    input_series:
      - series: 'node_network_receive_errs_total{instance="test-model_1234_test-app_test-app/0", device="eth0"}'
        values: '0x10 0+10x10 0x10'
      - series: 'node_network_receive_packets_total{instance="test-model_1234_test-app_test-app/0", device="eth0"}'
        values: '1000+100x30'
      - series: 'node_network_transmit_errs_total{instance="test-model_1234_test-app_test-app/0", device="eth0"}'
        values: '0x10 0+5x10 0x10'
      - series: 'node_network_transmit_packets_total{instance="test-model_1234_test-app_test-app/0", device="eth0"}'
        values: '1000+100x30'
    alert_rule_test:
      - eval_time: 5m
        alertname: HostNetworkReceiveErrors
        exp_alerts: []  # no alert
      - eval_time: 5m
        alertname: HostNetworkTransmitErrors
        exp_alerts: []  # no alert
      - eval_time: 15m
        alertname: HostNetworkReceiveErrors
        exp_alerts:
          - exp_labels:
              severity: warning
              device: eth0
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Interface 'eth0' network receive to many errors (instance test-model_1234_test-app_test-app/0)
              description: >-
                Interface 'eth0' has encountered 0.1000% receive errors in the last two minutes on host test-model_1234_test-app_test-app/0.
                  VALUE = 0.09999999999999999
                  LABELS = map[device:eth0 instance:test-model_1234_test-app_test-app/0]
      - eval_time: 15m
        alertname: HostNetworkTransmitErrors
        exp_alerts:
          - exp_labels:
              severity: warning
              device: eth0
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Interface 'eth0' network transmit to many errors (instance test-model_1234_test-app_test-app/0)
              description: >-
                Interface 'eth0' has encountered 0.0500% transmit errors in the last two minutes on host test-model_1234_test-app_test-app/0.
                  VALUE = 0.049999999999999996
                  LABELS = map[device:eth0 instance:test-model_1234_test-app_test-app/0]
  # test bonding
  - interval: 1m
    input_series:
      - series: 'node_bonding_active{instance="test-model_1234_test-app_test-app/0", master="bond0"}'
        values: '2x10'
      - series: 'node_bonding_slaves{instance="test-model_1234_test-app_test-app/0", master="bond0"}'
        values: '2x10'
      - series: 'node_bonding_active{instance="test-model_1234_test-app_test-app/0", master="bond1"}'
        values: '2x5 1x5'
      - series: 'node_bonding_slaves{instance="test-model_1234_test-app_test-app/0", master="bond1"}'
        values: '2x10'
    alert_rule_test:
      - eval_time: 6m
        alertname: HostNetworkBondDegraded
        exp_alerts: []  # no alert
      - eval_time: 7m
        alertname: HostNetworkBondDegraded
        exp_alerts: []  # no alert
      - eval_time: 8m
        alertname: HostNetworkBondDegraded
        exp_alerts:
          - exp_labels:
              severity: warning
              master: bond1
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Host bond network is degraded (instance test-model_1234_test-app_test-app/0)
              description: >-
                Host bond `bond1` network is degraded.
                  VALUE = -1
                  LABELS = map[instance:test-model_1234_test-app_test-app/0 master:bond1]
```
and promtool
```bash
x1:➜  prometheus_alert_rules git:(nrpe/network-aler-rules) ✗ promtool test rules ./test_network.yaml
Unit Testing:  ./test_network.yaml
  SUCCESS
                                                                                  [0.21s]
```

## Release Notes
- add alert rule for interface MTU size change
- add alert rule for interface speed change
- add alert rule for interface DOWN
- add alert rule for high network receive/transmit errors
- add alert rule for bond degradation