### PR TITLE
Add alert rules for reboot

### DIFF
--- a/src/prometheus_alert_rules/reboot.rules
+++ b/src/prometheus_alert_rules/reboot.rules
@@ -1,0 +1,14 @@
+groups:
+- name: HostReboot
+  rules:
+  - alert: HostReboot
+    expr: changes(node_boot_time_seconds[1m]) > 0
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: Host machine was reboot recently (instance {{ $labels.instance }})
+      description: >-
+        Host machine was reboot recently.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/reboot.rules
+++ b/src/prometheus_alert_rules/reboot.rules
@@ -2,13 +2,13 @@ groups:
 - name: HostReboot
   rules:
   - alert: HostReboot
-    expr: changes(node_boot_time_seconds[1m]) > 0
-    for: 1m
+    expr: changes(node_boot_time_seconds[5m]) > 0 and node_boot_time_seconds != (node_boot_time_seconds offset 1m)
+    for: 0m
     labels:
       severity: warning
     annotations:
-      summary: Host machine was reboot recently (instance {{ $labels.instance }})
+      summary: Host machine rebooted recently (instance {{ $labels.instance }})
       description: >-
-        Host machine was reboot recently.
+        Host machine rebooted recently.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}


### PR DESCRIPTION
- add alert rule for reboot detection

## Context
Moving network NRPE checks from [charm-nrpe](https://git.launchpad.net/charm-nrpe/tree/files/plugins).


## Testing Instructions
Tested with
```yaml
rule_files:
  - reboot.rules

evaluation_interval: 1m

tests:
  # test two restarts firing only one alert
  - interval: 1m
    input_series:
      - series: 'node_boot_time_seconds{instance="test-model_1234_test-app_test-app/0"}'
        values: '100x5 105x2 107x5'  # boot times 100, 105 and 107
    alert_rule_test:
      - eval_time: 5m
        alertname: HostReboot
        exp_alerts: []  # no alert
      - eval_time: 6m
        alertname: HostReboot
        exp_alerts:
          - exp_labels:
              severity: warning
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Host machine rebooted recently (instance test-model_1234_test-app_test-app/0)
              description: >-
                Host machine rebooted recently.
                  VALUE = 1
                  LABELS = map[instance:test-model_1234_test-app_test-app/0]
      - eval_time: 7m
        alertname: HostReboot
        exp_alerts: []  # no alert
      - eval_time: 8m
        alertname: HostReboot
        exp_alerts: []  # no alert
      - eval_time: 9m
        alertname: HostReboot
        exp_alerts:
          - exp_labels:
              severity: warning
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Host machine rebooted recently (instance test-model_1234_test-app_test-app/0)
              description: >-
                Host machine rebooted recently.
                  VALUE = 2
                  LABELS = map[instance:test-model_1234_test-app_test-app/0]
      - eval_time: 10m
        alertname: HostReboot
        exp_alerts: []  # no alert
  # test no values during booting
  - interval: 1m
    input_series:
      - series: 'node_boot_time_seconds{instance="test-model_1234_test-app_test-app/0"}'
        values: '100x5 _x2 107x5'  # boot times 100 and 110, 2m no data during boot time
    alert_rule_test:
      - eval_time: 5m
        alertname: HostReboot
        exp_alerts: []  # no alert
      - eval_time: 6m
        alertname: HostReboot
        exp_alerts: []  # no alert
      - eval_time: 7m
        alertname: HostReboot
        exp_alerts: []  # no alert
      - eval_time: 8m
        alertname: HostReboot
        exp_alerts:
          - exp_labels:
              severity: warning
              instance: test-model_1234_test-app_test-app/0
            exp_annotations:
              summary: Host machine rebooted recently (instance test-model_1234_test-app_test-app/0)
              description: >-
                Host machine rebooted recently.
                  VALUE = 1
                  LABELS = map[instance:test-model_1234_test-app_test-app/0]
      - eval_time: 9m
        alertname: HostReboot
        exp_alerts: []  # no alert
```
and promtool
```bashx1:➜  prometheus_alert_rules git:(nrpe/uptime-aler-rules) ✗ promtool test rules ./test_reboot.yaml
Unit Testing:  ./test_reboot.yaml
  SUCCESS
                                                                                                  [0.08s]
```

## Release Notes
- add alert rule for reboot detection
