### PR TITLE
Add Prometheus rules for pressure stall information.

### DIFF
--- a/src/prometheus_alert_rules/pressure.rules
+++ b/src/prometheus_alert_rules/pressure.rules
@@ -7,7 +7,7 @@ groups:
     expr: irate(node_pressure_cpu_waiting_seconds_total[5m]) > 0.9
     for: 5m
     labels:
-      severity: info
+      severity: warning
     annotations:
       summary: Host processes spent too much time waiting for CPU resources (instance {{ $labels.instance }})
       description: The instantanoues time that the processes spent on waiting for CPU resource is too high. This might indicates that the server is under high CPU pressure.\n  VALUE = {{ $value | printf "%.2f" }}\n  LABELS = {{ $labels }}
@@ -17,7 +17,7 @@ groups:
     expr: irate(node_pressure_io_waiting_seconds_total[5m]) > 0.5
     for: 5m
     labels:
-      severity: info
+      severity: warning
     annotations:
       summary: Host processes spent too much time waiting due to I/O congestion (instance {{ $labels.instance }})
       description: The instantanoues time that the processes spent on waiting for I/O is too high. This might indicates that the server is under high I/O pressure.\n  VALUE = {{ $value | printf "%.2f" }}\n  LABELS = {{ $labels }}
@@ -27,7 +27,7 @@ groups:
     expr: irate(node_pressure_memory_waiting_seconds_total[5m]) > 0.5
     for: 5m
     labels:
-      severity: info
+      severity: warning
     annotations:
       summary: Host processes spent too much time waiting for memory (instance {{ $labels.instance }})
       description: The instantanoues time that the processes spent on waiting for memory is too high. This might indicates that the server is under high memory pressure.\n  VALUE = {{ $value | printf "%.2f" }}\n  LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/pressure.rules
+++ b/src/prometheus_alert_rules/pressure.rules
@@ -1,0 +1,33 @@
+groups:
+- name: HostPressure
+  rules:
+
+  # Alert for host cpu pressure - high instantanoues cpu waiting time
+  - alert: HostHighCpuWaitingTime
+    expr: irate(node_pressure_cpu_waiting_seconds_total[5m]) > 0.9
+    for: 5m
+    labels:
+      severity: info
+    annotations:
+      summary: Host processes spent too much time waiting for CPU resources (instance {{ $labels.instance }})
+      description: The instantanoues time that the processes spent on waiting for CPU resource is too high. This might indicates that the server is under high CPU pressure.\n  VALUE = {{ $value | printf "%.2f" }}\n  LABELS = {{ $labels }}
+
+  # Alert for host io pressure - high instantanoues io waiting time
+  - alert: HostHighIOWaitingTime
+    expr: irate(node_pressure_io_waiting_seconds_total[5m]) > 0.5
+    for: 5m
+    labels:
+      severity: info
+    annotations:
+      summary: Host processes spent too much time waiting due to I/O congestion (instance {{ $labels.instance }})
+      description: The instantanoues time that the processes spent on waiting for I/O is too high. This might indicates that the server is under high I/O pressure.\n  VALUE = {{ $value | printf "%.2f" }}\n  LABELS = {{ $labels }}
+
+  # Alert for host mem pressure - high instantanoues mem waiting time
+  - alert: HostHighMemoryWaitingTime
+    expr: irate(node_pressure_memory_waiting_seconds_total[5m]) > 0.5
+    for: 5m
+    labels:
+      severity: info
+    annotations:
+      summary: Host processes spent too much time waiting for memory (instance {{ $labels.instance }})
+      description: The instantanoues time that the processes spent on waiting for memory is too high. This might indicates that the server is under high memory pressure.\n  VALUE = {{ $value | printf "%.2f" }}\n  LABELS = {{ $labels }}


### PR DESCRIPTION
## Issue
Moving OS-level NRPE checks (CPU related) from [charm-nrpe](https://git.launchpad.net/charm-nrpe/tree/files/plugins).

## Solution
Adding reasonable default Prometheus alert rule in Granada agent charm.

## Context
Create alert rules based on [pressure stall information (PSI)](https://www.kernel.org/doc/html/latest/accounting/psi.html)

## Testing Instructions
Tested with `promtool`
```yaml
rule_files:
  - pressure.rules

evaluation_interval: 1m

tests:

  - interval: 1m
    input_series:
      - series: 'node_pressure_cpu_waiting_seconds_total{instance="test-instance-1", job="node"}'
        values: '0+20x15' # rate = 0.33
      - series: 'node_pressure_io_waiting_seconds_total{instance="test-instance-1", job="node"}'
        values: '0+20x15' # rate = 0.33
      - series: 'node_pressure_memory_waiting_seconds_total{instance="test-instance-1", job="node"}'
        values: '0+20x15' # rate = 0.33

      - series: 'node_pressure_cpu_waiting_seconds_total{instance="test-instance-2", job="node"}'
        values: '0+60x15' # rate = 1.0 !
      - series: 'node_pressure_io_waiting_seconds_total{instance="test-instance-2", job="node"}'
        values: '0+20x15' # rate = 0.33
      - series: 'node_pressure_memory_waiting_seconds_total{instance="test-instance-2", job="node"}'
        values: '0+20x15' # rate = 0.33

      - series: 'node_pressure_cpu_waiting_seconds_total{instance="test-instance-3", job="node"}'
        values: '0+20x15' # rate = 0.33
      - series: 'node_pressure_io_waiting_seconds_total{instance="test-instance-3", job="node"}'
        values: '0+40x15' # rate = 0.67 !
      - series: 'node_pressure_memory_waiting_seconds_total{instance="test-instance-3", job="node"}'
        values: '0+20x15' # rate = 0.33

      - series: 'node_pressure_cpu_waiting_seconds_total{instance="test-instance-4", job="node"}'
        values: '0+20x15' # rate = 0.33
      - series: 'node_pressure_io_waiting_seconds_total{instance="test-instance-4", job="node"}'
        values: '0+20x15' # rate = 0.33
      - series: 'node_pressure_memory_waiting_seconds_total{instance="test-instance-4", job="node"}'
        values: '0+40x15' # rate = 0.67 !

    alert_rule_test:

      - eval_time: 6m
        alertname: HostHighCpuWaitingTime
        exp_alerts:
          - exp_labels:
              severity: info
              instance: test-instance-2
              job: node
            exp_annotations:
              summary: Host processes spent too much time waiting for CPU resources (instance test-instance-2)
              description: The instantanoues time that the processes spent on waiting for CPU resource is too high. This might indicates that the server is under high CPU pressure.\n  VALUE = 1.00\n  LABELS = map[instance:test-instance-2 job:node]

      - eval_time: 6m
        alertname: HostHighIOWaitingTime
        exp_alerts:
          - exp_labels:
              severity: info
              instance: test-instance-3
              job: node
            exp_annotations:
              summary: Host processes spent too much time waiting due to I/O congestion (instance test-instance-3)
              description: The instantanoues time that the processes spent on waiting for I/O is too high. This might indicates that the server is under high I/O pressure.\n  VALUE = 0.67\n  LABELS = map[instance:test-instance-3 job:node]

      - eval_time: 6m
        alertname: HostHighMemoryWaitingTime
        exp_alerts:
          - exp_labels:
              severity: info
              instance: test-instance-4
              job: node
            exp_annotations:
              summary: Host processes spent too much time waiting for memory (instance test-instance-4)
              description: The instantanoues time that the processes spent on waiting for memory is too high. This might indicates that the server is under high memory pressure.\n  VALUE = 0.67\n  LABELS = map[instance:test-instance-4 job:node]
```

Result

```bash
Unit Testing:  test_pressure.yaml
  SUCCESS
```

## Release Notes
- Add Prometheus alert group: `HostPressure`
    - alert rule for `HostHighCpuWaitingTime`
    - alert rule for `HostHighIOWaitingTime`
    - alert rule for `HostHighMemoryWaitingTime`