### PR TITLE
Add Prometheus alert rule for processes.

### DIFF
--- a/src/prometheus_alert_rules/process.rules
+++ b/src/prometheus_alert_rules/process.rules
@@ -1,0 +1,23 @@
+groups:
+- name: HostProcesses
+  rules:
+
+  # Alert for too many processes
+  - alert: TooManyProcesses
+    expr: node_processes_pids / node_processes_max_processes * 100 > 80
+    for: 0m
+    labels:
+      severity: info
+    annotations:
+      summary: Too many processes on the host machine (instance {{ $labels.instance }})
+      description: There are too many processes on the host machine, and it's reaching 80% of the maximum processes.\n  VALUE = {{ $value | printf "%.2f" }}\n  LABELS = {{ $labels }}
+
+  # Alert for processes kept increasing
+  - alert: ProcessesIncresingWarning
+    expr: deriv(node_processes_pids[1m]) > 0
+    for: 5m
+    labels:
+      severity: info
+    annotations:
+      summary: Process count is kept increasing (instance {{ $labels.instance }})
+      description: The number of processes seem to be growing for the last 5 minutes.\n  VALUE = {{ $value | printf "%.2f"}}\n  LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/process.rules
+++ b/src/prometheus_alert_rules/process.rules
@@ -10,7 +10,7 @@ groups:
       severity: info
     annotations:
       summary: Too many processes on the host machine (instance {{ $labels.instance }})
-      description: There are too many processes on the host machine, and it's reaching 80% of the maximum processes.\n  VALUE = {{ $value | printf "%.2f" }}\n  LABELS = {{ $labels }}
+      description: There are too many processes on the host machine. The current process count is 80% or more of the  max.\n  VALUE = {{ $value | printf "%.2f" }}\n  LABELS = {{ $labels }}
 
   # Alert for processes kept increasing
   - alert: ProcessesIncresingWarning


### PR DESCRIPTION
## Issue
Moving OS-level NRPE checks (Processes related) from [charm-nrpe](https://git.launchpad.net/charm-nrpe/tree/files/plugins).


## Solution
Adding reasonable default Prometheus alert rule in Granada agent charm.


## Context
These alert rules depends on `collector.processes` which is currently not enabled by default, and is not configurable in this charm (or grafana-agent snap to be more specific). These alert rules won't be effective if issue #162 is not resolved.


## Testing Instructions

Tested with `promtool`

```yaml
rule_files:
  - process.rules

evaluation_interval: 1m

tests:

  - interval: 1m
    input_series:
      - series: 'node_processes_max_processes{instance="test-instance-0", job="node"}'
        values: 4194304
      - series: 'node_processes_pids{instance="test-instance-0", job="node"}'
        values: 4

      - series: 'node_processes_max_processes{instance="test-instance-1", job="node"}'
        values: 4194304
      - series: 'node_processes_pids{instance="test-instance-1", job="node"}'
        values: 3955444 # !

      - series: 'node_processes_pids{instance="test-instance-2", job="node"}'
        values: '10x3 5x3 10x3'

      - series: 'node_processes_pids{instance="test-instance-3", job="node"}'
        values: '600+10x6' # !


    alert_rule_test:

      - eval_time: 0m
        alertname: TooManyProcesses
        exp_alerts:
          - exp_labels:
              severity: info
              instance: test-instance-1
              job: node
            exp_annotations:
              summary: Too many processes on the host machine (instance test-instance-1)
              description: There are too many processes on the host machine, and it's reaching 80% of the maximum processes.\n  VALUE = 94.31\n  LABELS = map[instance:test-instance-1 job:node]

      - eval_time: 6m
        alertname: ProcessesIncresingWarning
        exp_alerts:
          - exp_labels:
              severity: info
              instance: test-instance-3
              job: node
            exp_annotations:
              summary: Process count is kept increasing (instance test-instance-3)
              description: The number of processes seem to be growing for the last 5 minutes.\n  VALUE = 0.17\n  LABELS = map[instance:test-instance-3 job:node]
```

Result

```bash
Unit Testing:  test_process.yaml
  SUCCESS
```

Also, I validated the query `expr`  in a self-deployed environment with node exporter and Prometheus.

## Release Notes
- Add Prometheus alert group: `HostProcesses`
    - alert rule for `TooManyProcesses`
    - alert rule for `ProcessesIncresingWarning`
