### PR TITLE
enable some additional useful collectors

### DIFF
--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -325,7 +325,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                     "sysctl",
                 ],
                 "sysctl_include": [
-                    "net.ipv4.neigh.default.gc_thresh3"
+                    "net.ipv4.neigh.default.gc_thresh3",
                 ],
                 "relabel_configs": [
                     # Align the "job" name with those of prometheus_scrape

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -317,6 +317,13 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         return {
             "node_exporter": {
                 "enabled": True,
+                "enable_collectors": [
+                  "logind",
+                  "systemd",
+                  "mountstats",
+                  "processes",
+                  "sysctl",
+                ],
                 "relabel_configs": [
                     # Align the "job" name with those of prometheus_scrape
                     {

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -324,6 +324,9 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
                   "processes",
                   "sysctl",
                 ],
+                "sysctl_include": [
+                  "net.ipv4.neigh.default.gc_thresh3"
+                ],
                 "relabel_configs": [
                     # Align the "job" name with those of prometheus_scrape
                     {

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -318,14 +318,14 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
             "node_exporter": {
                 "enabled": True,
                 "enable_collectors": [
-                  "logind",
-                  "systemd",
-                  "mountstats",
-                  "processes",
-                  "sysctl",
+                    "logind",
+                    "systemd",
+                    "mountstats",
+                    "processes",
+                    "sysctl",
                 ],
                 "sysctl_include": [
-                  "net.ipv4.neigh.default.gc_thresh3"
+                    "net.ipv4.neigh.default.gc_thresh3"
                 ],
                 "relabel_configs": [
                     # Align the "job" name with those of prometheus_scrape


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
https://github.com/canonical/grafana-agent-k8s-operator/pull/197 won't work without the optional `logind` and `systemd` collectors enabled.

## Solution
<!-- A summary of the solution addressing the above issue -->
Enabling the two collectors above, as well as a couple of additional ones that could prove useful.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Deploy and make sure the `node_systemd_unit_state` metric is properly populated.

## Release Notes
<!-- A digestable summary of the change in this PR -->
Enable additional optional collectors.