### PR TITLE
Grafana agent require only one outgoing relation to be Active

### DIFF
--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -6,7 +6,7 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "e6f580481c1b4388aa4d2cdf412a47fa"
 LIBAPI = 0
-LIBPATCH = 2
+LIBPATCH = 3
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 
@@ -39,7 +39,7 @@ class GrafanaCloudConfigEvents(ObjectEvents):
 
 class GrafanaCloudConfigRequirer(Object):
 
-    on = GrafanaCloudConfigEvents()
+    on = GrafanaCloudConfigEvents()  # pyright: ignore
 
     def __init__(self, charm, relation_name = DEFAULT_RELATION_NAME):
         super().__init__(charm, relation_name)
@@ -64,13 +64,13 @@ class GrafanaCloudConfigRequirer(Object):
             ]):
                 return
 
-        self.on.cloud_config_available.emit()
+        self.on.cloud_config_available.emit()  # pyright: ignore
 
     def _on_relation_broken(self, event):
         if not self._charm.unit.is_leader():
             return
 
-        self.on.cloud_config_revoked.emit()
+        self.on.cloud_config_revoked.emit()  # pyright: ignore
     
     def _is_not_empty(self, s):
         return bool(s and not s.isspace())

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -27,9 +27,12 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     """K8s version of the Grafana Agent charm."""
 
     mandatory_relation_pairs = [
-        ("metrics-endpoint", ["send-remote-write", "grafana-cloud-config"]),
-        ("grafana-dashboards-consumer", ["grafana-dashboards-provider", "grafana-cloud-config"]),
-        ("logging-provider", ["logging-consumer", "grafana-cloud-config"]),
+        ("metrics-endpoint", (["send-remote-write"], ["grafana-cloud-config"])),
+        (
+            "grafana-dashboards-consumer",
+            (["grafana-dashboards-provider"], ["grafana-cloud-config"]),
+        ),
+        ("logging-provider", (["logging-consumer"], ["grafana-cloud-config"])),
     ]
 
     def __init__(self, *args):

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -26,14 +26,20 @@ SCRAPE_RELATION_NAME = "metrics-endpoint"
 class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     """K8s version of the Grafana Agent charm."""
 
-    mandatory_relation_pairs = [
-        ("metrics-endpoint", (["send-remote-write"], ["grafana-cloud-config"])),
-        (
-            "grafana-dashboards-consumer",
-            (["grafana-dashboards-provider"], ["grafana-cloud-config"]),
-        ),
-        ("logging-provider", (["logging-consumer"], ["grafana-cloud-config"])),
-    ]
+    mandatory_relation_pairs = {
+        "metrics-endpoint": [  # must be paired with:
+            {"send-remote-write"},  # or
+            {"grafana-cloud-config"},
+        ],
+        "logging-provider": [  # must be paired with:
+            {"logging-consumer"},  # or
+            {"grafana-cloud-config"},
+        ],
+        "grafana-dashboards-consumer": [  # must be paired with:
+            {"grafana-dashboards-provider"},  # or
+            {"grafana-cloud-config"},
+        ],
+    }
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -149,11 +149,14 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
     service_name = "grafana-agent.grafana-agent"
 
     mandatory_relation_pairs = [
-        ("cos-agent", ["send-remote-write", "grafana-cloud-config"]),
-        ("cos-agent", ["logging-consumer", "grafana-cloud-config"]),
-        ("cos-agent", ["grafana-dashboards-provider", "grafana-cloud-config"]),
-        ("juju-info", ["send-remote-write", "grafana-cloud-config"]),
-        ("juju-info", ["logging-consumer", "grafana-cloud-config"]),
+        (
+            "cos-agent",
+            (
+                ["grafana-cloud-config"],
+                ["send-remote-write", "logging-consumer", "grafana-dashboards-provider"],
+            ),
+        ),
+        ("juju-info", (["grafana-cloud-config"], ["send-remote-write", "logging-consumer"])),
     ]
 
     def __init__(self, *args):

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -148,16 +148,16 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
 
     service_name = "grafana-agent.grafana-agent"
 
-    mandatory_relation_pairs = [
-        (
-            "cos-agent",
-            (
-                ["grafana-cloud-config"],
-                ["send-remote-write", "logging-consumer", "grafana-dashboards-provider"],
-            ),
-        ),
-        ("juju-info", (["grafana-cloud-config"], ["send-remote-write", "logging-consumer"])),
-    ]
+    mandatory_relation_pairs = {
+        "cos-agent": [  # must be paired with:
+            {"grafana-cloud-config"},  # or
+            {"send-remote-write", "logging-consumer", "grafana-dashboards-provider"},
+        ],
+        "juju-info": [  # must be paired with:
+            {"grafana-cloud-config"},  # or
+            {"send-remote-write", "logging-consumer"},
+        ],
+    }
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,7 +24,7 @@ async def test_build_and_deploy(ops_test, grafana_agent_charm):
     await ops_test.model.deploy(grafana_agent_charm, resources=resources, application_name="agent")
 
     await ops_test.model.wait_for_idle(
-        apps=["agent"], status="active", timeout=300, idle_period=30
+        apps=["agent"], status="blocked", timeout=300, idle_period=30
     )
     assert ops_test.model.applications["agent"].units[0].workload_status == "blocked"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -32,4 +32,8 @@ async def test_build_and_deploy(ops_test, grafana_agent_charm):
 async def test_relates_to_loki(ops_test):
     await ops_test.model.deploy("loki-k8s", channel="edge", application_name="loki", trust=True)
     await ops_test.model.add_relation("loki", "agent:logging-consumer")
-    await ops_test.model.wait_for_idle(apps=["loki", "agent"], status="active", timeout=1000)
+
+    await ops_test.model.wait_for_idle(
+        apps=["agent"], status="blocked", timeout=300  # Missing incoming ('requires') relation
+    )
+    await ops_test.model.wait_for_idle(apps=["loki"], status="active", timeout=300)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -26,7 +26,7 @@ async def test_build_and_deploy(ops_test, grafana_agent_charm):
     await ops_test.model.wait_for_idle(
         apps=["agent"], status="active", timeout=300, idle_period=30
     )
-    assert ops_test.model.applications["agent"].units[0].workload_status == "active"
+    assert ops_test.model.applications["agent"].units[0].workload_status == "blocked"
 
 
 async def test_relates_to_loki(ops_test):

--- a/tests/integration/test_forwards_alerts.py
+++ b/tests/integration/test_forwards_alerts.py
@@ -37,7 +37,7 @@ async def test_deploy(ops_test, grafana_agent_charm):
     # issuing placeholder update_status just to trigger an event
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})
 
-    await ops_test.model.wait_for_idle(apps=[agent_name], status="active", timeout=300)
+    await ops_test.model.wait_for_idle(apps=[agent_name], status="blocked", timeout=300)
     assert ops_test.model.applications[agent_name].units[0].workload_status == "blocked"
 
 

--- a/tests/integration/test_forwards_alerts.py
+++ b/tests/integration/test_forwards_alerts.py
@@ -38,7 +38,7 @@ async def test_deploy(ops_test, grafana_agent_charm):
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})
 
     await ops_test.model.wait_for_idle(apps=[agent_name], status="active", timeout=300)
-    assert ops_test.model.applications[agent_name].units[0].workload_status == "active"
+    assert ops_test.model.applications[agent_name].units[0].workload_status == "blocked"
 
 
 async def test_relate_to_external_apps(ops_test):
@@ -61,7 +61,7 @@ async def test_relate_to_loki_tester_and_check_alerts(ops_test, loki_tester_char
     await ops_test.model.deploy(loki_tester_charm, application_name=loki_tester_name)
     await ops_test.model.add_relation(agent_name, loki_tester_name)
     await ops_test.model.wait_for_idle(
-        apps=[loki_tester_name, agent_name], status="active", timeout=300
+        apps=[loki_tester_name, agent_name], status="blocked", timeout=300
     )
 
     loki_alerts = await loki_rules(ops_test, loki_name)
@@ -80,7 +80,7 @@ async def test_relate_to_prometheus_tester_and_check_alerts(ops_test, prometheus
     )
     await ops_test.model.add_relation(agent_name, prometheus_tester_name)
     await ops_test.model.wait_for_idle(
-        apps=[prometheus_tester_name, agent_name], status="active", timeout=300
+        apps=[prometheus_tester_name, agent_name], status="blocked", timeout=300
     )
 
     prometheus_alerts = await prometheus_rules(ops_test, prometheus_name, 0)

--- a/tests/integration/test_forwards_alerts.py
+++ b/tests/integration/test_forwards_alerts.py
@@ -53,7 +53,10 @@ async def test_relate_to_external_apps(ops_test):
         ops_test.model.add_relation(f"{prometheus_name}:receive-remote-write", agent_name),
     )
     await ops_test.model.wait_for_idle(
-        apps=[loki_name, prometheus_name, agent_name], status="active", timeout=300
+        apps=[loki_name, prometheus_name], status="active", timeout=300
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[agent_name], status="blocked", timeout=300  # Missing incoming ('requires') relation
     )
 
 
@@ -61,7 +64,7 @@ async def test_relate_to_loki_tester_and_check_alerts(ops_test, loki_tester_char
     await ops_test.model.deploy(loki_tester_charm, application_name=loki_tester_name)
     await ops_test.model.add_relation(agent_name, loki_tester_name)
     await ops_test.model.wait_for_idle(
-        apps=[loki_tester_name, agent_name], status="blocked", timeout=300
+        apps=[loki_tester_name, agent_name], status="active", timeout=300
     )
 
     loki_alerts = await loki_rules(ops_test, loki_name)
@@ -80,7 +83,7 @@ async def test_relate_to_prometheus_tester_and_check_alerts(ops_test, prometheus
     )
     await ops_test.model.add_relation(agent_name, prometheus_tester_name)
     await ops_test.model.wait_for_idle(
-        apps=[prometheus_tester_name, agent_name], status="blocked", timeout=300
+        apps=[prometheus_tester_name, agent_name], status="active", timeout=300
     )
 
     prometheus_alerts = await prometheus_rules(ops_test, prometheus_name, 0)

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -25,7 +25,7 @@ async def test_deploy_from_local_path(ops_test, grafana_agent_charm):
     await ops_test.model.deploy(
         grafana_agent_charm, application_name=app_name, resources=resources
     )
-    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[app_name], status="blocked", timeout=1000)
 
 
 @pytest.mark.xfail

--- a/tests/scenario/test_setup_statuses.py
+++ b/tests/scenario/test_setup_statuses.py
@@ -8,7 +8,7 @@ import grafana_agent
 import k8s_charm
 import machine_charm
 import pytest
-from ops import ActiveStatus, UnknownStatus, WaitingStatus, pebble
+from ops import BlockedStatus, UnknownStatus, WaitingStatus, pebble
 from ops.testing import CharmType
 from scenario import Container, ExecOutput, State, trigger
 
@@ -105,6 +105,6 @@ def test_k8s_charm_start_with_container(charm_type, substrate, vroot):
         charm_root=vroot,
     )
 
-    assert out.status.unit == ActiveStatus("")
+    assert out.status.unit == BlockedStatus("Missing incoming ('requires') relation")
     agent_out = out.get_container("agent")
     assert agent_out.services["agent"].current == pebble.ServiceStatus.ACTIVE

--- a/tests/scenario/test_start_statuses.py
+++ b/tests/scenario/test_start_statuses.py
@@ -117,10 +117,10 @@ def test_start(charm_type, charm_meta, substrate, vroot, placeholder_cfg_path):
         written_cfg = placeholder_cfg_path.read_text()
         assert written_cfg  # check nonempty
 
-        assert out.status.unit == ("active", "")
+        assert out.status.unit.name == "blocked"
 
     else:
-        assert out.status.unit == ("unknown", "")
+        assert out.status.unit.name == "unknown"
 
 
 def test_k8s_charm_start_with_container(charm_type, charm_meta, substrate, vroot):
@@ -140,6 +140,6 @@ def test_k8s_charm_start_with_container(charm_type, charm_meta, substrate, vroot
     )
     out = ctx.run(state=State(containers=[agent]), event=agent.pebble_ready_event)
 
-    assert out.status.unit == ("active", "")
+    assert out.status.unit.name == "blocked"
     agent_out = out.get_container("agent")
     assert agent_out.services["agent"].current == pebble.ServiceStatus.ACTIVE

--- a/tests/unit/k8s/test_relation_status.py
+++ b/tests/unit/k8s/test_relation_status.py
@@ -27,13 +27,13 @@ class TestRelationStatus(unittest.TestCase):
     def test_no_relations(self):
         # GIVEN no relations joined (see SetUp)
         # WHEN the charm starts (see SetUp)
-        # THEN status is "active"
-        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+        # THEN status is "blocked"
+        self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
         # AND WHEN "update-status" fires
         self.harness.charm.on.update_status.emit()
-        # THEN status is still "active"
-        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+        # THEN status is still "blocked"
+        self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
     def test_with_relations(self):
         for incoming, outgoing in [
@@ -43,16 +43,21 @@ class TestRelationStatus(unittest.TestCase):
         ]:
             with self.subTest(incoming=incoming, outgoing=outgoing):
                 # WHEN an incoming relation is added
-                rel_id = self.harness.add_relation(incoming, "grafana-agent")
-                self.harness.add_relation_unit(rel_id, "grafana-agent/0")
-                self.harness.update_relation_data(rel_id, "grafana-agent/0", {"sample": "value"})
+                rel_incoming_id = self.harness.add_relation(incoming, "grafana-agent")
+                self.harness.add_relation_unit(rel_incoming_id, "grafana-agent/0")
+                self.harness.update_relation_data(
+                    rel_incoming_id, "grafana-agent/0", {"sample": "value"}
+                )
 
                 # THEN the charm goes into blocked status
                 self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
                 # AND WHEN an appropriate outgoing relation is added
-                rel_id = self.harness.add_relation(outgoing, "grafana-agent")
-                self.harness.add_relation_unit(rel_id, "grafana-agent/0")
+                rel_outgoing_id = self.harness.add_relation(outgoing, "grafana-agent")
+                self.harness.add_relation_unit(rel_outgoing_id, "grafana-agent/0")
 
                 # THEN the charm goes into active status
                 self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+                # Remove incoming relation.
+                self.harness.remove_relation(rel_incoming_id)

--- a/tests/unit/k8s/test_scrape_configuration.py
+++ b/tests/unit/k8s/test_scrape_configuration.py
@@ -109,6 +109,10 @@ class TestScrapeConfiguration(unittest.TestCase):
 
         agent_container = self.harness.charm.unit.get_container("agent")
 
+        # Add incoming relation
+        rel_incoming_id = self.harness.add_relation("metrics-endpoint", "agent")
+        self.harness.add_relation_unit(rel_incoming_id, "agent/0")
+
         rel_id = self.harness.add_relation("send-remote-write", "prometheus")
 
         self.harness.add_relation_unit(rel_id, "prometheus/0")

--- a/tests/unit/machine/test_relation_status.py
+++ b/tests/unit/machine/test_relation_status.py
@@ -36,13 +36,13 @@ class TestRelationStatus(unittest.TestCase):
     def test_no_relations(self):
         # GIVEN no relations joined (see SetUp)
         # WHEN the charm starts (see SetUp)
-        # THEN status is "active"
-        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+        # THEN status is "blocked"
+        self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
         # AND WHEN "update-status" fires
         self.harness.charm.on.update_status.emit()
-        # THEN status is still "active"
-        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+        # THEN status is still "blocked"
+        self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
     def test_cos_agent_with_relations(self):
         # WHEN an incoming relation is added
@@ -52,22 +52,19 @@ class TestRelationStatus(unittest.TestCase):
         # THEN the charm goes into blocked status
         self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
-        # AND WHEN all the necessary outgoing relations are added
+        # AND WHEN at least one of the necessary outgoing relations is added
         for outgoing in ["send-remote-write", "logging-consumer", "grafana-dashboards-provider"]:
-            # Before the relation is added, the charm is still in blocked status
-            self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
-
             rel_id = self.harness.add_relation(outgoing, "grafana-agent")
             self.harness.add_relation_unit(rel_id, "grafana-agent/0")
 
-        # THEN the charm goes into active status
-        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+            # THEN the charm goes into active status when one mandatory relation is added
+            self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
 
-        # AND WHEN we remove one mandatory relation
+        # AND WHEN we remove one of the mandatory relations
         self.harness.remove_relation(rel_id)
 
-        # THEN the charm goes into blocked status again
-        self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
+        # THEN the charm keeps into active status
+        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
 
     def test_juju_info_with_relations(self):
         # WHEN an incoming relation is added
@@ -79,9 +76,6 @@ class TestRelationStatus(unittest.TestCase):
 
         # AND WHEN all the necessary outgoing relations are added
         for outgoing in ["send-remote-write", "logging-consumer"]:
-            # Before the relation is added, the charm is still in blocked status
-            self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
-
             rel_id = self.harness.add_relation(outgoing, "grafana-agent")
             self.harness.add_relation_unit(rel_id, "grafana-agent/0")
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR fixes #200

## Solution
<!-- A summary of the solution addressing the above issue -->

https://github.com/canonical/grafana-agent-k8s-operator/issues/200#issuecomment-1576949493

> We could update the ActiveStatus with a message about which ones are disabled, like: `Metrics: off` or `Metrics & Dashboards: off`.

![imagen](https://github.com/canonical/grafana-agent-k8s-operator/assets/939888/81ec1f4a-58a1-4f4b-9c9d-74a646309f52)


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Before this change you need the following three relations (or grafana-dashboards-provider) to be established to get grafana-agent in ActiveStatus:

- grafana-cloud-config
- send-remote-write
- logging-consumer



## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run tests ;-)

