### PR TITLE
feat: Add prometheus alert rules for nvme

### DIFF
--- a/src/prometheus_alert_rules/nvme.rule
+++ b/src/prometheus_alert_rules/nvme.rule
@@ -1,0 +1,32 @@
+---
+groups:
+  - name: nvme
+    rules:
+      - record: available_file_size_percentage
+        expr: |
+          100 *  (node_filesystem_avail_bytes / node_filesystem_size_bytes)
+      - alert: FileSystemPercentUsedWarn
+        expr: |
+          avg_over_time(available_file_size_percentage[5m]) < 20
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Available disk on {{ $labels.mountpoint }} is too low
+          description: Available disk percentage on mountpoint({{ $labels.mountpoint }}) {{ $value }} is < 20%
+      - alert: FileSystemPercentUsedCrit
+        expr: |
+          avg_over_time(available_file_size_percentage[5m]) < 10
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Available disk on {{ $labels.mountpoint }} is too low
+          description: Available disk percentage on mountpoint({{ $labels.mountpoint }}) {{ $value }} is < 10%
+      - alert: NvmeHwmonTempAlarm
+        expr: node_hwmon_temp_alarm != 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: Chip {{ $labels.chip }} throw a temperature alarm {{ $value }}


### PR DESCRIPTION
## Context

Add nvme prometheus alert rules

## Testing Instructions
Tested with

```yaml
rule_files:
  - ./nvme.rule
evaluation_interval: 1m
tests:
  - interval: 1m
    input_series:
      - series: node_hwmon_temp_alarm{chip="nvme_nvme1", sensor="temp1"}
        values: 1
    alert_rule_test:
      - eval_time: 1m
        alertname: NvmeHwmonTempAlarm
        exp_alerts:
          - exp_labels:
              alertname: NvmeHwmonTempAlarm
              chip: "nvme_nvme1"
              severity: warning
              sensor: "temp1"
            exp_annotations:
              summary: Chip nvme_nvme1 throw a temperature alarm 1
  - interval: 1m
    input_series:
      - series: node_filesystem_avail_bytes{device="/dev/nvme1n1p2",fstype="ext4",mountpoint="/"}
        values: 19
      - series: node_filesystem_size_bytes{device="/dev/nvme1n1p2",fstype="ext4",mountpoint="/"}
        values: 100
    alert_rule_test:
      - eval_time: 5m
        alertname: FileSystemPercentUsedWarn
        exp_alerts:
          - exp_labels:
              alertname: FileSystemPercentUsedWarn
              severity: warning
              device: "/dev/nvme1n1p2"
              fstype: "ext4"
              mountpoint: "/"
            exp_annotations:
              summary: Available disk on / is too low
              description: Available disk percentage on mountpoint(/) 19 is < 20%
  - interval: 1m
    input_series:
      - series: node_filesystem_avail_bytes{device="/dev/nvme1n1p2",fstype="ext4",mountpoint="/boot/efi"}
        values: 5
      - series: node_filesystem_size_bytes{device="/dev/nvme1n1p2",fstype="ext4",mountpoint="/boot/efi"}
        values: 100
    alert_rule_test:
      - eval_time: 5m
        alertname: FileSystemPercentUsedCrit
        exp_alerts:
          - exp_labels:
              alertname: FileSystemPercentUsedWarn
              severity: critical
              device: "/dev/nvme1n1p2"
              fstype: "ext4"
              mountpoint: "/boot/efi"
            exp_annotations:
              summary: Available disk on /boot/efi is too low
              description: Available disk percentage on mountpoint(/boot/efi) 5 is < 10%

```

## Release Notes
- Add alert rule for nvme