### PR TITLE
feat: Add alert rule for hwmon

### DIFF
--- a/src/prometheus_alert_rules/hwmon.rules
+++ b/src/prometheus_alert_rules/hwmon.rules
@@ -1,0 +1,16 @@
+---
+groups:
+  - name: hwmon
+    rules:
+      - alert: HwmonTempAlarm
+        expr: node_hwmon_temp_alarm != 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: Chip {{ $labels.chip }} is throwing a temperature alarm on {{ $labels.instance }}
+          description: >-
+            Chip {{ $labels.chip }} is throwing a temperature alarm on {{ $labels.instance }}
+              VALUE = {{ $value }}
+              LABELS = {{ $labels }}
+


### PR DESCRIPTION
## Context
- Add alert rule for hwmon temperature alarm


## Testing Instructions
```
rule_files:
  - ./hwmon.rules
evaluation_interval: 1m
tests:
  - interval: 1m
    input_series:
      - series: node_hwmon_temp_alarm{chip="nvme_nvme1", sensor="temp1", instance="instanceA"}
        values: 1
    alert_rule_test:
      - eval_time: 1m
        alertname: HwmonTempAlarm
        exp_alerts:
          - exp_labels:
              alertname: HwmonTempAlarm
              chip: "nvme_nvme1"
              severity: warning
              sensor: "temp1"
              instance: "instanceA"
            exp_annotations:
              summary: Chip nvme_nvme1 is throwing a temperature alarm on instanceA
              description: >-
                Chip nvme_nvme1 is throwing a temperature alarm on instanceA
                  VALUE = 1
                  LABELS = map[__name__:node_hwmon_temp_alarm chip:nvme_nvme1 instance:instanceA sensor:temp1]

```

## Release Notes
- Add alert rule for hwmon temperature alarm