### PR TITLE
Add alert rules based on mdadm metrics

### DIFF
--- a/src/prometheus_alert_rules/mdadm.rules
+++ b/src/prometheus_alert_rules/mdadm.rules
@@ -1,0 +1,50 @@
+groups:
+- name: mdadm
+  rules:
+    - alert: RaidDisksFailed  
+      expr: node_md_disks{state="failed"} > 0
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: "{{ $value }} disks failed on device {{ $labels.device }}.(instance {{ $labels.instance }})"
+        description: >-
+          Disks failed on raid device {{ $labels.device }}.
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
+
+    - alert: RaidDisksSpare
+      expr: node_md_disks{state="spare"} > 0
+      for: 0m
+      labels:
+        severity: warning
+      annotations:
+        summary: "{{ $value }} disks marked as spare on device {{ $labels.device }}.(instance {{ $labels.instance }})"
+        description: >-
+          Disks marked as spare on raid device {{ $labels.device }}.
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
+
+    - alert: RaidDeviceInactive
+      expr: node_md_state{state="inactive"} > 0
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: RAID device {{ $labels.device }} in inactive state.(instance {{ $labels.instance }})
+        description: >-
+          RAID device {{ $labels.device }} in inactive state.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+
+    - alert: RaidDeviceRecovering
+      expr: node_md_state{state="recovering"} > 0
+      for: 0m
+      labels:
+        severity: warning
+      annotations:
+        summary: RAID device {{ $labels.device }} in recovering state.(instance {{ $labels.instance }})
+        description: >-
+          RAID device {{ $labels.device }} in recovering state.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}


### PR DESCRIPTION
## Context
* Add alert rules based on mdadm metrics. 


## Testing Instructions

Tested with

```
rule_files:
  - ./mdadm.rules

evaluation_interval: 1m

tests:
  - interval: 1m
    input_series: 
      - series: node_md_disks{device="md0", state="active", instance="ubuntu-0"}
        values: '1x15'
      - series: node_md_disks{device="md1", state="failed", instance="ubuntu-0"}
        values: '2x15'

    alert_rule_test:
      - eval_time: 0m
        alertname: RaidDisksFailed
        exp_alerts:
          - exp_labels:
              severity: critical
              device: md1
              state: failed
              instance: ubuntu-0
            exp_annotations:
              summary: 2 disks failed on device md1.(instance ubuntu-0)
              description: >-
                Disks failed on raid device md1.
                  VALUE = 2
                  LABELS = map[__name__:node_md_disks device:md1 instance:ubuntu-0 state:failed]

  - interval: 1m
    input_series: 
      - series: node_md_disks{device="md0", state="spare", instance="ubuntu-0"}
        values: '3x15'
      - series: node_md_disks{device="md1", state="failed", instance="ubuntu-0"}
        values: '2x15'

    alert_rule_test:
      - eval_time: 0m
        alertname: RaidDisksSpare
        exp_alerts:
          - exp_labels:
              severity: warning
              device: md0
              state: spare
              instance: ubuntu-0
            exp_annotations:
              summary: 3 disks marked as spare on device md0.(instance ubuntu-0)
              description: >-
                Disks marked as spare on raid device md0.
                  VALUE = 3
                  LABELS = map[__name__:node_md_disks device:md0 instance:ubuntu-0 state:spare]

  - interval: 1m
    input_series: 
      - series: node_md_state{device="md0", state="inactive", instance="ubuntu-0"}
        values: '1x15'
      - series: node_md_state{device="md1", state="active", instance="ubuntu-0"}
        values: '1x15'

    alert_rule_test:
      - eval_time: 0m
        alertname: RaidDeviceInactive
        exp_alerts:
          - exp_labels:
              severity: critical
              device: md0
              state: inactive
              instance: ubuntu-0
            exp_annotations:
              summary: RAID device md0 in inactive state.(instance ubuntu-0)
              description: >-
                RAID device md0 in inactive state.
                VALUE = 1
                LABELS = map[__name__:node_md_state device:md0 instance:ubuntu-0 state:inactive]

  - interval: 1m
    input_series: 
      - series: node_md_state{device="md0", state="recovering", instance="ubuntu-0"}
        values: '0x15'
      - series: node_md_state{device="md1", state="recovering", instance="ubuntu-0"}
        values: '1x15'

    alert_rule_test:
      - eval_time: 0m
        alertname: RaidDeviceRecovering
        exp_alerts:
          - exp_labels:
              severity: warning
              device: md1
              state: recovering
              instance: ubuntu-0
            exp_annotations:
              summary: RAID device md1 in recovering state.(instance ubuntu-0)
              description: >-
                RAID device md1 in recovering state.
                VALUE = 1
                LABELS = map[__name__:node_md_state device:md1 instance:ubuntu-0 state:recovering]

```

and promtool

```
$ promtool test rules ./test_mdadm.yaml
Unit Testing:  ./test_mdadm.yaml
  SUCCESS
```

## Release Notes
* Add alert rules for detecting issues with mdadm disks and devices.
