### PR TITLE
Pin pydantic's major version

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -189,9 +189,9 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 4
+LIBPATCH = 5
 
-PYDEPS = ["cosl", "pydantic"]
+PYDEPS = ["cosl", "pydantic<2"]
 
 DEFAULT_RELATION_NAME = "cos-agent"
 DEFAULT_PEER_RELATION_NAME = "peers"

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -352,7 +352,7 @@ class COSAgentProvider(Object):
                     )
                     relation.data[self._charm.unit][data.KEY] = data.json()
                 except (
-                    pydantic.error_wrappers.ValidationError,
+                    pydantic.ValidationError,
                     json.decoder.JSONDecodeError,
                 ) as e:
                     logger.error("Invalid relation data provided: %s", e)
@@ -525,7 +525,7 @@ class COSAgentRequirer(Object):
     def _validated_provider_data(self, raw) -> Optional[CosAgentProviderUnitData]:
         try:
             return CosAgentProviderUnitData(**json.loads(raw))
-        except (pydantic.error_wrappers.ValidationError, json.decoder.JSONDecodeError) as e:
+        except (pydantic.ValidationError, json.decoder.JSONDecodeError) as e:
             self.on.validation_error.emit(message=str(e))  # pyright: ignore
             return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # That's why we are including cosl here until the bug in charmcraft is solved
 cosl
 ops
-pydantic
+pydantic<2
 requests
 kubernetes
 lightkube

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -17,6 +17,7 @@ from charms.observability_libs.v1.kubernetes_service_patch import (
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from grafana_agent import CONFIG_PATH, GrafanaAgentCharm
 from ops.main import main
+from ops.pebble import Layer
 
 logger = logging.getLogger(__name__)
 
@@ -78,18 +79,20 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     def _on_agent_pebble_ready(self, _event) -> None:
         self._container.push(CONFIG_PATH, yaml.dump(self._generate_config()), make_dirs=True)
 
-        pebble_layer = {
-            "summary": "agent layer",
-            "description": "pebble config layer for Grafana Agent",
-            "services": {
-                "agent": {
-                    "override": "replace",
-                    "summary": "agent",
-                    "command": f"/bin/agent {self._cli_args()}",
-                    "startup": "enabled",
+        pebble_layer = Layer(
+            {
+                "summary": "agent layer",
+                "description": "pebble config layer for Grafana Agent",
+                "services": {
+                    "agent": {
+                        "override": "replace",
+                        "summary": "agent",
+                        "command": f"/bin/agent {self._cli_args()}",
+                        "startup": "enabled",
+                    },
                 },
-            },
-        }
+            }
+        )
         self._container.add_layer(self._name, pebble_layer, combine=True)
         self._container.autostart()
 


### PR DESCRIPTION
## Issue
Closes #214 

When packing charmcraft will install and update dependencies of charm libraries overriding pins set in the charm's `requirements.txt`. Since there's no version restriction set in `cos-agent` PYDEPS for pydantic, charmcraft will always update and pull the latest version, which will break charms using it. 


## Solution
Pin pydantic in the cos-agent charm library to less than 2


## Context
Charmcraft issue:
https://github.com/canonical/charmcraft/issues/1135

And PR:
https://github.com/canonical/charmcraft/pull/1136

## Testing Instructions
N/A


## Release Notes
Pin pydantic's major version in cos-agent PYDEPS
