### PR TITLE
Do not override static config labels

### DIFF
--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -255,7 +255,11 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         for job in jobs:
             static_configs = job.get("static_configs", [])
             for static_config in static_configs:
-                static_config["labels"] = self._principal_labels
+                static_config["labels"] = {
+                    # Be sure to keep labels from static_config
+                    **static_config.get("labels", {}),
+                    **self._principal_labels,
+                }
         return jobs
 
     def logs_rules(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

The grafana-agent charm will override any existing labels that may be configured in the static_configs

## Solution
<!-- A summary of the solution addressing the above issue -->

Use `static_config.setdefault("labels", {})`, and then update the dict so that:

- If any `labels` are set in the static config, they are preserved and the juju topology labels are added
- If no `labels` are set in the config, this is equivalent to the previous behavior

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Needed for https://github.com/canonical/charm-microk8s/pull/88 (along with a few more PRs I'm making separately)

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Supply a static config with existing labels, expect that they are not removed from the resulting scrape jobs.

## Release Notes
<!-- A digestable summary of the change in this PR -->

Respect any labels defined in the metrics endpoints.
