### PR TITLE
Allow custom scrape jobs in COSAgentProvider

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -722,7 +722,9 @@ class COSAgentRequirer(Object):
         scrape_jobs = []
         if data := self._principal_unit_data:
             for job in data.metrics_scrape_jobs:
-                # This is to ensure backwards compatibility with old clients
+                # In #220, relation schema changed from a simplified dict to the standard
+                # `scrape_configs`.
+                # This is to ensure backwards compatibility with Providers older than v0.5.
                 if "path" in job and "port" in job and "job_name" in job:
                     job = {
                         "job_name": job["job_name"],


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Scrape jobs may require more fields, e.g. `authorization` or custom labels for specific targets

## Solution
<!-- A summary of the solution addressing the above issue -->

If the metrics endpoint passed to `COSAgentProvider` has a `scrape_job` field, then assume that this is a custom job, also added docs (happy to adjust with any recommendation)

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Needed for https://github.com/canonical/charm-microk8s/pull/88, also see to #219 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->

Allow custom scrape jobs in COSAgentProvider