### PR TITLE
Do not fail if dashboard titles contain slashes

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -321,7 +321,7 @@ class GrafanaAgentCharm(CharmBase):
             # Build dashboard custom filename
             charm = dash.get("charm", "charm-name")
             rel_id = dash.get("relation_id", "rel_id")
-            title = dash.get("title").replace(" ", "_").lower()
+            title = dash.get("title").replace(" ", "_").replace("/", "_").lower()
             filename = f"juju_{title}-{charm}-{rel_id}.json"
 
             with open(pathlib.Path(mapping.dest, filename), mode="w", encoding="utf-8") as f:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

If dashboard titles contain slashes, then the grafana-agent charm fails to handle them properly.

Essentially, the dashboard data is written on a local file, and the dashboard title is used to construct the filename. Any slashes `/` are preserved, therefore would need intermediate dirs to exist. The file write just below will fail, since the directory does not exist.

## Solution
<!-- A summary of the solution addressing the above issue -->

Replace `/` with `_` (it should not matter)

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Came up during https://github.com/canonical/charm-microk8s/pull/88

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->

Properly handle dashboards that contain dashes (`/`) in their title
