### PR TITLE
Always update the cos-agent relation

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -171,7 +171,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Set, Unio
 import pydantic
 from cosl import JujuTopology
 from cosl.rules import AlertRules
-from ops.charm import RelationChangedEvent, RelationEvent
+from ops.charm import RelationChangedEvent
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
 from ops.model import Relation, Unit
 from ops.testing import CharmType
@@ -331,10 +331,7 @@ class COSAgentProvider(Object):
 
     def _on_refresh(self, event):
         """Trigger the class to update relation data."""
-        if isinstance(event, RelationEvent):
-            relations = [event.relation]
-        else:
-            relations = self._charm.model.relations[self._relation_name]
+        relations = self._charm.model.relations[self._relation_name]
 
         for relation in relations:
             # Before a principal is related to the grafana-agent subordinate, we'd get


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

The `refresh_events` field of `COSAgentProvider` are a list of events that should cause a refresh of the `cos-agent` relation data. However, sometimes a wrong relation may be updated instead of the cos-agent relation. Consider the following example:

```yaml
# metadata.yaml

peers:
  peer:
    interface: peer

provides:
  cos-agent:
    interface: cos_agent
```

```py
# src/charm.py
self._cos = COSAgentProvider(
    relation_name="cos-agent",
    refresh_events=[self.on.peer_relation_changed, self.on.upgrade_charm]
)
```

With the above, we want to update the `cos-agent` relation when a change happens to the peer relation. However, the updated unit data is written on the `peer` relation instead, since `isinstance(event, RelationEvent)` is true and `event.relation` refers to the peer relation.

I could pinpoint the problem by adding relevant log lines in the `_on_refresh` method:

```
unit-microk8s-0: 16:53:15 INFO unit.microk8s/0.juju-log Refresh triggered by <UpgradeCharmEvent via MicroK8sCharm/on/upgrade_charm[1081]>
unit-microk8s-0: 16:53:17 INFO unit.microk8s/0.juju-log Writing into <ops.model.Relation cos-agent:11>
unit-microk8s-0: 16:53:17 INFO juju.worker.uniter.operation ran "upgrade-charm" hook (via hook dispatching script: dispatch)
unit-microk8s-0: 16:53:17 INFO juju.worker.uniter found queued "config-changed" hook
unit-microk8s-0: 16:53:20 INFO juju.worker.uniter.operation ran "config-changed" hook (via hook dispatching script: dispatch)
unit-microk8s-0: 16:53:54 INFO unit.microk8s/0.juju-log peer:0: Refresh triggered by <RelationChangedEvent via MicroK8sCharm/on/peer_relation_changed[1087]>
unit-microk8s-0: 16:53:57 INFO unit.microk8s/0.juju-log peer:0: Writing into <ops.model.Relation peer:0>
unit-microk8s-0: 16:53:58 INFO juju.worker.uniter.operation ran "peer-relation-changed" hook (via hook dispatching script: dispatch)                                       
```
Note that the right relation data is updated when the `upgrade_charm` event is fired, since it is not a relation event.

## Solution
<!-- A summary of the solution addressing the above issue -->

The unit data must always be written to the `cos-agent` relation unit data. After the change of this PR, the logs are now:

```
unit-microk8s-0: 21:30:25 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)                                    
unit-microk8s-0: 21:30:27 INFO unit.microk8s/0.juju-log peer:0: Refresh triggered by <RelationChangedEvent via MicroK8sCharm/on/peer_relation_changed[1417]>    
unit-microk8s-0: 21:30:29 INFO unit.microk8s/0.juju-log peer:0: Writing into <ops.model.Relation cos-agent:11>                                                  
unit-microk8s-0: 21:30:29 INFO juju.worker.uniter.operation ran "peer-relation-changed" hook (via hook dispatching script: dispatch)                            
unit-grafana-agent-5: 21:30:35 INFO juju.worker.uniter.operation ran "cos-agent-relation-changed" hook (via hook dispatching script: dispatch)                  
unit-grafana-agent-5: 21:33:03 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)                               
```

We also see that the grafana-agent unit picks up the change this time.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Needed for https://github.com/canonical/charm-microk8s/pull/88

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->

Properly update cos-agent relation unit data when a relation event is used as `refresh_event`.