### PR TITLE
apply principal labels to alert rules defined by grafana-agent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ kubernetes
 lightkube
 lightkube-models
 cryptography
-jsonschema
+jsonschema < 4  # Pin prevents the machine charm error "ModuleNotFoundError: No module named 'rpds.rpds'"

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -110,7 +110,7 @@ class GrafanaAgentCharm(CharmBase):
             dest=charm_root.joinpath(*DASHBOARDS_DEST_PATH.split("/")),
         )
 
-        for rules in [self.loki_rules_paths, self.metrics_rules_paths, self.dashboard_paths]:
+        for rules in [self.loki_rules_paths, self.dashboard_paths]:
             if not os.path.isdir(rules.dest):
                 shutil.copytree(rules.src, rules.dest, dirs_exist_ok=True)
 
@@ -314,6 +314,7 @@ class GrafanaAgentCharm(CharmBase):
             alerts_func=self.logs_rules,
             reload_func=self._loki_consumer._reinitialize_alert_rules,
             mapping=self.loki_rules_paths,
+            copy_files=True,
         )
 
     def _update_grafana_dashboards(self):
@@ -329,15 +330,25 @@ class GrafanaAgentCharm(CharmBase):
             return self._recurse_call_chain(maybe_func())
         return maybe_func
 
-    def update_alerts_rules(self, alerts_func: Any, reload_func: Callable, mapping: RulesMapping):
+    def update_alerts_rules(
+        self,
+        alerts_func: Any,
+        reload_func: Callable,
+        mapping: RulesMapping,
+        copy_files: bool = False,
+    ):
         """Copy alert rules from relations and save them to disk."""
         # MetricsEndpointConsumer.alerts is not @property, but Loki is, so
         # do the right thing. With an additional layer of indirection, recurse
         # to the bottom until we find a real List|Dict|not-Callable
         rules = self._recurse_call_chain(alerts_func)
 
-        shutil.rmtree(mapping.dest)
-        shutil.copytree(mapping.src, mapping.dest)
+        if os.path.exists(mapping.dest):
+            shutil.rmtree(mapping.dest)
+        if copy_files:
+            shutil.copytree(mapping.src, mapping.dest)
+        else:
+            os.mkdir(mapping.dest)
         for topology_identifier, rule in rules.items():
             file_handle = pathlib.Path(mapping.dest, "juju_{}.rules".format(topology_identifier))
             file_handle.write_text(yaml.dump(rule))

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -219,6 +219,11 @@ class GrafanaAgentCharm(CharmBase):
         self._update_config()
 
     # Abstract Methods
+    @property
+    def is_k8s(self) -> bool:
+        """Is this a k8s charm."""
+        raise NotImplementedError("Please override the is_k8s method")
+
     def agent_version_output(self) -> str:
         """Gets the raw output from `agent -version`."""
         raise NotImplementedError("Please override the agent_version_output method")
@@ -307,6 +312,7 @@ class GrafanaAgentCharm(CharmBase):
             alerts_func=self.metrics_rules,
             reload_func=self._remote_write.reload_alerts,
             mapping=self.metrics_rules_paths,
+            copy_files=self.is_k8s,  # TODO: This is ugly
         )
 
     def _update_loki_alerts(self):

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -120,6 +120,11 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         return self._loki_provider.alerts
 
     @property
+    def is_k8s(self) -> bool:
+        """Is this a k8s charm."""
+        return True
+
+    @property
     def is_ready(self):
         """Checks if the charm is ready for configuration."""
         return self._container.can_connect()

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -277,7 +277,7 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         own_rules = AlertRules(query_type="promql", topology=topology)
         own_rules.add_path(METRICS_RULES_SRC_PATH)
         if topology.identifier in rules:
-            rules[topology.identifier]["groups"].append(own_rules.as_dict()["groups"])
+            rules[topology.identifier]["groups"] += own_rules.as_dict()["groups"]
         else:
             rules[topology.identifier] = own_rules.as_dict()
         return rules

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -256,6 +256,11 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm):
         except snap.SnapError as e:
             raise GrafanaAgentInstallError("Failed to uninstall grafana-agent") from e
 
+    @property
+    def is_k8s(self) -> bool:
+        """Is this a k8s charm."""
+        return False
+
     def metrics_rules(self) -> Dict[str, Any]:
         """Return a list of metrics rules."""
         rules = self._cos.metrics_alerts


### PR DESCRIPTION
## Issue
Alert rule labels do not match metrics labels.


## Solution
Apply the principal topology to alert rules defined by grafana-agent.

Fixes #190.

## Testing Instructions
1. Deploy grafana-agent
2. Deploy ubuntu
3. Relate cos -> grafana-agent -> ubuntu
4. Check that the alert rules are labeled as "ubuntu" rather than "grafana-agent"


## Release Notes
Fixed an issue where alert rule labels did not match metrics labels.

## Note
This is draft at the moment because I need to add tests and investigate whether the same change is needed for logging alerts.