### PR TITLE
fix(k8s): forward dashboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 tests/integration/*-tester/lib/
 metadata.yaml
 src/charm.py
+.env

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -206,17 +206,15 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm)
 ```
 """
 
-import base64
 import json
 import logging
-import lzma
 from collections import namedtuple
 from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Set, Union
 
 import pydantic
-from cosl import JujuTopology, GrafanaDashboard
+from cosl import GrafanaDashboard, JujuTopology
 from cosl.rules import AlertRules
 from ops.charm import RelationChangedEvent
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
@@ -249,7 +247,6 @@ DEFAULT_SCRAPE_CONFIG = {
 
 logger = logging.getLogger(__name__)
 SnapEndpoint = namedtuple("SnapEndpoint", "owner, name")
-
 
 
 class CosAgentProviderUnitData(pydantic.BaseModel):

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -216,7 +216,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Set, Union
 
 import pydantic
-from cosl import JujuTopology
+from cosl import JujuTopology, GrafanaDashboard
 from cosl.rules import AlertRules
 from ops.charm import RelationChangedEvent
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
@@ -250,30 +250,6 @@ DEFAULT_SCRAPE_CONFIG = {
 logger = logging.getLogger(__name__)
 SnapEndpoint = namedtuple("SnapEndpoint", "owner, name")
 
-
-class GrafanaDashboard(str):
-    """Grafana Dashboard encoded json; lzma-compressed."""
-
-    # TODO Replace this with a custom type when pydantic v2 released (end of 2023 Q1?)
-    # https://github.com/pydantic/pydantic/issues/4887
-    @staticmethod
-    def _serialize(raw_json: Union[str, bytes]) -> "GrafanaDashboard":
-        if not isinstance(raw_json, bytes):
-            raw_json = raw_json.encode("utf-8")
-        encoded = base64.b64encode(lzma.compress(raw_json)).decode("utf-8")
-        return GrafanaDashboard(encoded)
-
-    def _deserialize(self) -> Dict:
-        try:
-            raw = lzma.decompress(base64.b64decode(self.encode("utf-8"))).decode()
-            return json.loads(raw)
-        except json.decoder.JSONDecodeError as e:
-            logger.error("Invalid Dashboard format: %s", e)
-            return {}
-
-    def __repr__(self):
-        """Return string representation of self."""
-        return "<GrafanaDashboard>"
 
 
 class CosAgentProviderUnitData(pydantic.BaseModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # https://chat.charmhub.io/charmhub/pl/wngp665ycjnb78ar9ojrfhxjkr
 # That's why we are including cosl here until the bug in charmcraft is solved
 cosl
-ops < 2.5.0  # https://github.com/canonical/ops-scenario/issues/48
+ops > 2.5.0
 pydantic < 2
 requests
 kubernetes

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -365,8 +365,6 @@ class GrafanaAgentCharm(CharmBase):
         self, dashboards: Any, reload_func: Callable, mapping: RulesMapping
     ) -> None:
         """Copy dashboards from relations, save them to disk, and update."""
-
-
         shutil.rmtree(mapping.dest)
         shutil.copytree(mapping.src, mapping.dest)
         for dash in dashboards:

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -368,7 +368,7 @@ class GrafanaAgentCharm(CharmBase):
         try:
             dashboards = dashboards_func
         except NotImplementedError:
-            logger.debug("Dashboard forwarding is not yet enabled for k8s grafana-agent")
+            logger.error("Dashboard forwarding is not yet enabled for this substrate!")
             return
 
         shutil.rmtree(mapping.dest)

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -325,7 +325,7 @@ class GrafanaAgentCharm(CharmBase):
 
     def _update_grafana_dashboards(self):
         self.update_dashboards(
-            dashboards_func=self.dashboards,
+            dashboards=self.dashboards,
             reload_func=self._grafana_dashboards_provider._update_all_dashboards_from_dir,
             mapping=self.dashboard_paths,
         )
@@ -362,14 +362,10 @@ class GrafanaAgentCharm(CharmBase):
         reload_func()
 
     def update_dashboards(
-        self, dashboards_func: Any, reload_func: Callable, mapping: RulesMapping
+        self, dashboards: Any, reload_func: Callable, mapping: RulesMapping
     ) -> None:
         """Copy dashboards from relations, save them to disk, and update."""
-        try:
-            dashboards = dashboards_func
-        except NotImplementedError:
-            logger.error("Dashboard forwarding is not yet enabled for this substrate!")
-            return
+
 
         shutil.rmtree(mapping.dest)
         shutil.copytree(mapping.src, mapping.dest)

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -10,13 +10,13 @@ import pathlib
 from typing import Any, Dict, List, Union
 
 import yaml
-from cosl import GrafanaDashboard
 from charms.loki_k8s.v0.loki_push_api import LokiPushApiProvider
 from charms.observability_libs.v1.kubernetes_service_patch import (
     KubernetesServicePatch,
     ServicePort,
 )
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
+from cosl import GrafanaDashboard
 from grafana_agent import CONFIG_PATH, GrafanaAgentCharm
 from ops.main import main
 from ops.pebble import Layer
@@ -104,7 +104,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     def _on_dashboards_changed(self, _event) -> None:
         logger.info("updating dashboards")
 
-        if not self._charm.unit.is_leader():
+        if not self.unit.is_leader():
             return
 
         self.update_dashboards(
@@ -136,7 +136,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         """Returns an aggregate of all dashboards received by this grafana-agent."""
         aggregate = {}
         for rel in self.model.relations["grafana-dashboards-consumer"]:
-            dashboards = json.loads(rel.data[rel.app].get("dashboards", ""))  # type: ignore
+            dashboards = json.loads(rel.data[rel.app].get("dashboards", "{}"))  # type: ignore
             if "templates" not in dashboards:
                 continue
             for template in dashboards["templates"]:

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -4,11 +4,13 @@
 # See LICENSE file for licensing details.
 
 """A  juju charm for Grafana Agent on Kubernetes."""
+import json
 import logging
 import pathlib
 from typing import Any, Dict, List, Union
 
 import yaml
+from charms.grafana_agent.v0.cos_agent import GrafanaDashboard
 from charms.loki_k8s.v0.loki_push_api import LokiPushApiProvider
 from charms.observability_libs.v1.kubernetes_service_patch import (
     KubernetesServicePatch,
@@ -62,9 +64,15 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         self._loki_provider = LokiPushApiProvider(
             self, relation_name="logging-provider", port=self._http_listen_port
         )
+
         self.framework.observe(
             self._loki_provider.on.loki_push_api_alert_rules_changed,  # pyright: ignore
             self._on_loki_push_api_alert_rules_changed,
+        )
+
+        self.framework.observe(
+            self.on["grafana-dashboards-consumer"].relation_changed,
+            self._on_dashboards_changed,
         )
 
         self.framework.observe(
@@ -93,6 +101,14 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
             },
         )
 
+    def _on_dashboards_changed(self, _event) -> None:
+        logger.info("updating dashboards")
+        self.update_dashboards(
+            dashboards_func=self.dashboards,
+            reload_func=self._grafana_dashboards_provider._update_all_dashboards_from_dir,
+            mapping=self.dashboard_paths,
+        )
+
     def _on_agent_pebble_ready(self, _event) -> None:
         self._container.push(CONFIG_PATH, yaml.dump(self._generate_config()), make_dirs=True)
 
@@ -110,6 +126,28 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     def metrics_rules(self) -> Dict[str, Any]:
         """Return a list of metrics rules."""
         return self._scrape.alerts
+
+    @property
+    def dashboards(self) -> list:
+        """Returns an aggregate of all dashboards received by this grafana-agent."""
+        aggregate = {}
+        for rel in self.model.relations["grafana-dashboards-consumer"]:
+            dashboards = json.loads(rel.data[rel.app].get("dashboards"))
+            if "templates" not in dashboards:
+                continue
+            for template in dashboards["templates"]:
+                content = GrafanaDashboard(
+                    dashboards["templates"][template].get("content")
+                )._deserialize()
+                entry = {
+                    "charm": dashboards["templates"][template].get("charm", "charm_name"),
+                    "relation_id": rel.id,
+                    "title": template,
+                    "content": content,
+                }
+                aggregate[template] = entry
+
+        return aggregate.values()
 
     def metrics_jobs(self) -> list:
         """Return a list of metrics scrape jobs."""

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -103,6 +103,10 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
 
     def _on_dashboards_changed(self, _event) -> None:
         logger.info("updating dashboards")
+
+        if not self._charm.unit.is_leader():
+            return
+
         self.update_dashboards(
             dashboards=self.dashboards,
             reload_func=self._grafana_dashboards_provider._update_all_dashboards_from_dir,

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -10,7 +10,7 @@ import pathlib
 from typing import Any, Dict, List, Union
 
 import yaml
-from charms.grafana_agent.v0.cos_agent import GrafanaDashboard
+from cosl import GrafanaDashboard
 from charms.loki_k8s.v0.loki_push_api import LokiPushApiProvider
 from charms.observability_libs.v1.kubernetes_service_patch import (
     KubernetesServicePatch,
@@ -136,7 +136,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         """Returns an aggregate of all dashboards received by this grafana-agent."""
         aggregate = {}
         for rel in self.model.relations["grafana-dashboards-consumer"]:
-            dashboards = json.loads(rel.data[rel.app].get("dashboards", "")) # type: ignore
+            dashboards = json.loads(rel.data[rel.app].get("dashboards", ""))  # type: ignore
             if "templates" not in dashboards:
                 continue
             for template in dashboards["templates"]:

--- a/src/k8s_charm.py
+++ b/src/k8s_charm.py
@@ -104,7 +104,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     def _on_dashboards_changed(self, _event) -> None:
         logger.info("updating dashboards")
         self.update_dashboards(
-            dashboards_func=self.dashboards,
+            dashboards=self.dashboards,
             reload_func=self._grafana_dashboards_provider._update_all_dashboards_from_dir,
             mapping=self.dashboard_paths,
         )
@@ -132,7 +132,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         """Returns an aggregate of all dashboards received by this grafana-agent."""
         aggregate = {}
         for rel in self.model.relations["grafana-dashboards-consumer"]:
-            dashboards = json.loads(rel.data[rel.app].get("dashboards"))
+            dashboards = json.loads(rel.data[rel.app].get("dashboards", "")) # type: ignore
             if "templates" not in dashboards:
                 continue
             for template in dashboards["templates"]:
@@ -147,7 +147,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
                 }
                 aggregate[template] = entry
 
-        return aggregate.values()
+        return list(aggregate.values())
 
     def metrics_jobs(self) -> list:
         """Return a list of metrics scrape jobs."""

--- a/tests/scenario/test_k8s/conftest.py
+++ b/tests/scenario/test_k8s/conftest.py
@@ -1,0 +1,11 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def patch_all():
+    with patch("k8s_charm.KubernetesServicePatch", lambda x, y: None):
+        yield

--- a/tests/scenario/test_k8s/test_dashboard_transfer.py
+++ b/tests/scenario/test_k8s/test_dashboard_transfer.py
@@ -1,0 +1,57 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+import json
+
+from cosl import GrafanaDashboard
+from k8s_charm import GrafanaAgentK8sCharm
+from scenario import Container, Context, Relation, State
+
+
+def encode_as_dashboard(dct: dict):
+    return GrafanaDashboard._serialize(json.dumps(dct).encode("utf-8"))
+
+
+class TestDashboardPropagation:
+    """TestDashboardPropagation checks that dashboard propagation works in the K8s charm."""
+
+    def test_dashboard_propagation(self, vroot):
+        # This test verifies that if the charm receives a dashboard via the requirer databag,
+        # it is correctly transferred to the provider databag.
+
+        content_in = encode_as_dashboard({"hello": "world"})
+        expected = {
+            "charm": "some-test-charm",
+            "title": "file:some-mock-dashboard",
+            "content": content_in,
+        }
+        data = {
+            "templates": {
+                "file:some-mock-dashboard": {"charm": "some-test-charm", "content": content_in}
+            }
+        }
+        consumer = Relation(
+            "grafana-dashboards-consumer",
+            relation_id=1,
+            remote_app_data={"dashboards": json.dumps(data)},
+        )
+
+        provider = Relation("grafana-dashboards-provider", relation_id=2)
+
+        ctx = Context(charm_type=GrafanaAgentK8sCharm, charm_root=vroot)
+        state = State(
+            relations=[consumer, provider],
+            leader=True,
+            containers=[Container("agent", can_connect=True)],
+        )
+
+        def post_event(charm):
+            dash = charm.dashboards[0]
+            assert dash["charm"] == expected["charm"]
+            assert dash["title"] == expected["title"]
+            assert dash["content"] == expected["content"]._deserialize()
+
+        ctx.run(
+            state=state,
+            event=consumer.changed_event,
+            post_event=post_event,
+        )

--- a/tests/scenario/test_machine_charm/test_peer_relation.py
+++ b/tests/scenario/test_machine_charm/test_peer_relation.py
@@ -4,11 +4,12 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
+
+from cosl import GrafanaDashboard
 from charms.grafana_agent.v0.cos_agent import (
     CosAgentPeersUnitData,
     CosAgentProviderUnitData,
     COSAgentRequirer,
-    GrafanaDashboard,
 )
 from charms.prometheus_k8s.v1.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,

--- a/tests/scenario/test_machine_charm/test_peer_relation.py
+++ b/tests/scenario/test_machine_charm/test_peer_relation.py
@@ -4,8 +4,6 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-
-from cosl import GrafanaDashboard
 from charms.grafana_agent.v0.cos_agent import (
     CosAgentPeersUnitData,
     CosAgentProviderUnitData,
@@ -14,6 +12,7 @@ from charms.grafana_agent.v0.cos_agent import (
 from charms.prometheus_k8s.v1.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,
 )
+from cosl import GrafanaDashboard
 from ops.charm import CharmBase
 from ops.framework import Framework
 from scenario import Context, PeerRelation, State, SubordinateRelation

--- a/tests/scenario/test_machine_charm/test_relation_priority.py
+++ b/tests/scenario/test_machine_charm/test_relation_priority.py
@@ -6,9 +6,8 @@ from unittest.mock import patch
 
 import machine_charm
 import pytest
-
-from cosl import GrafanaDashboard
 from charms.grafana_agent.v0.cos_agent import MultiplePrincipalsError
+from cosl import GrafanaDashboard
 from scenario import Context, PeerRelation, State, SubordinateRelation
 
 from tests.scenario.helpers import get_charm_meta

--- a/tests/scenario/test_machine_charm/test_relation_priority.py
+++ b/tests/scenario/test_machine_charm/test_relation_priority.py
@@ -6,7 +6,9 @@ from unittest.mock import patch
 
 import machine_charm
 import pytest
-from charms.grafana_agent.v0.cos_agent import GrafanaDashboard, MultiplePrincipalsError
+
+from cosl import GrafanaDashboard
+from charms.grafana_agent.v0.cos_agent import MultiplePrincipalsError
 from scenario import Context, PeerRelation, State, SubordinateRelation
 
 from tests.scenario.helpers import get_charm_meta

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 [tox]
 isolated_build = True
 skip_missing_interpreters = True
-envlist = lint, static-{charm,lib}, unit, unit-machine, scenario
+envlist = lint, static-{charm,lib}, unit, unit-machine, scenario, scenario-{k8s,machine}
 
 [vars]
 src_path = {toxinidir}/src
@@ -145,7 +145,15 @@ commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/integration
 
 [testenv:scenario]
-description = Run scenario tests
+skip_install=True
+allowlist_externals =
+  tox
+commands =
+    tox -e scenario-k8s
+    tox -e scenario-machine
+
+[testenv:scenario-machine]
+description = Run scenario tests on LXD
 deps =
     -r{toxinidir}/requirements.txt
     pytest
@@ -157,7 +165,7 @@ commands =
     pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/scenario/test_machine_charm --ignore {[vars]tst_path}/scenario/test_k8s
 
 [testenv:scenario-k8s]
-description = Run scenario tests for k8s
+description = Run scenario tests on K8s
 deps =
     -r{toxinidir}/requirements.txt
     pytest
@@ -167,7 +175,6 @@ commands =
     cp {[vars]src_path}/k8s_charm.py {[vars]src_path}/charm.py
     cp k8s_metadata.yaml metadata.yaml
     pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/scenario --ignore {[vars]tst_path}/scenario/test_machine_charm
-
 
 [testenv:integration-machine]
 description = Run integration tests (machine charm)

--- a/tox.ini
+++ b/tox.ini
@@ -154,7 +154,20 @@ allowlist_externals = cp
 commands =
     cp {[vars]src_path}/machine_charm.py {[vars]src_path}/charm.py
     cp machine_metadata.yaml metadata.yaml
-    pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/scenario
+    pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/scenario/test_machine_charm --ignore {[vars]tst_path}/scenario/test_k8s
+
+[testenv:scenario-k8s]
+description = Run scenario tests for k8s
+deps =
+    -r{toxinidir}/requirements.txt
+    pytest
+    ops-scenario > 4
+allowlist_externals = cp
+commands =
+    cp {[vars]src_path}/k8s_charm.py {[vars]src_path}/charm.py
+    cp k8s_metadata.yaml metadata.yaml
+    pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/scenario --ignore {[vars]tst_path}/scenario/test_machine_charm
+
 
 [testenv:integration-machine]
 description = Run integration tests (machine charm)


### PR DESCRIPTION
resolves #240 
resolves #87 

## Issue
<!-- What issue is this PR trying to solve? -->
currently, dashboards are only forwarded for the machine flavor of grafana agent

## Solution
<!-- A summary of the solution addressing the above issue -->
forward dashboards for k8s as well

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. deploy cos lite
2. deploy this bundle, with a local build of the charm:
```
bundle: pr-241
saas:
  grafana:
    url: uk8s:admin/cos.grafana
  prometheus:
    url: uk8s:admin/cos.prometheus
applications:
  ga:
    charm: local:grafana-agent-k8s-4
    channel: edge
    resources:
      agent-image: 30
    scale: 1
  pgsql:
    charm: postgresql-k8s
    channel: 14/edge
    revision: 128
    resources:
      postgresql-image: 116
    scale: 1
 relations:
- - ga:metrics-endpoint
  - pgsql:metrics-endpoint
- - ga:logging-provider
  - pgsql:logging
- - ga:send-remote-write
  - prometheus:receive-remote-write
- - ga:grafana-dashboards-provider
  - grafana:grafana-dashboard
- - ga:grafana-dashboards-consumer
  - pgsql:grafana-dashboard
```
3. look in grafana and make sure you have all the dashboards
![image](https://github.com/canonical/grafana-agent-k8s-operator/assets/1596025/537841cc-0606-46f6-8bf7-79b17e462e27)



## Release Notes
<!-- A digestable summary of the change in this PR -->
Forward dashboards on K8s.