### PR TITLE
Drop `charm-binary-python-packages` section

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,6 +16,14 @@ bases:
       architectures: ["amd64"]
 parts:
   charm:
-    charm-binary-python-packages: [cryptography, cosl, jsonschema]
     build-packages:
     - git
+
+    # The following are needed for tls-certificates-interface
+    - build-essential
+    - python3-dev
+    - libffi-dev
+    - libssl-dev
+    - pkg-config
+    - rustc
+    - cargo


### PR DESCRIPTION
## Issue
K8s charm fails on install hook ([ci ref](https://github.com/canonical/prometheus-k8s-operator/actions/runs/6090925554/job/16526669903?pr=518#step:5:1362)):
```
INFO juju.worker.uniter awaiting error resolution for "install" hook
WARNING unit.grafana-agent/0.install thread '<unnamed>' panicked at 'Python API call failed', /github/home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-0.18.3/src/err/mod.rs:790:5
WARNING unit.grafana-agent/0.install note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
WARNING unit.grafana-agent/0.install ModuleNotFoundError: No module named '_cffi_backend'
WARNING unit.grafana-agent/0.install Traceback (most recent call last):
WARNING unit.grafana-agent/0.install   File "./src/charm.py", line 20, in <module>
WARNING unit.grafana-agent/0.install     from grafana_agent import CONFIG_PATH, GrafanaAgentCharm
WARNING unit.grafana-agent/0.install   File "/var/lib/juju/agents/unit-grafana-agent-0/charm/src/grafana_agent.py", line 31, in <module>
WARNING unit.grafana-agent/0.install     from charms.observability_libs.v0.cert_handler import CertHandler
WARNING unit.grafana-agent/0.install   File "/var/lib/juju/agents/unit-grafana-agent-0/charm/lib/charms/observability_libs/v0/cert_handler.py", line 41, in <module>
WARNING unit.grafana-agent/0.install     from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore
WARNING unit.grafana-agent/0.install   File "/var/lib/juju/agents/unit-grafana-agent-0/charm/lib/charms/tls_certificates_interface/v2/tls_certificates.py", line 285, in <module>
WARNING unit.grafana-agent/0.install     from cryptography import x509
WARNING unit.grafana-agent/0.install   File "/var/lib/juju/agents/unit-grafana-agent-0/charm/venv/cryptography/x509/__init__.py", line 7, in <module>
WARNING unit.grafana-agent/0.install     from cryptography.x509 import certificate_transparency
WARNING unit.grafana-agent/0.install   File "/var/lib/juju/agents/unit-grafana-agent-0/charm/venv/cryptography/x509/certificate_transparency.py", line 11, in <module>
WARNING unit.grafana-agent/0.install     from cryptography.hazmat.bindings._rust import x509 as rust_x509
WARNING unit.grafana-agent/0.install pyo3_runtime.PanicException: Python API call failed
```


## Solution
Drop the `charm-binary-python-packages` section.


## Context
I imagine this issue came to be from the overlap of 3 other issues:
1. We use the same `charmcraft.yaml` for both k8s and machine charm. For subordinate machine charms it makes sense to `run-on` multiple series. For k8s it only matters because of [this juju bug](https://bugs.launchpad.net/juju/+bug/2030110).
2. We have multiple `run-on` under the same `build-on`. We should probably have two sections, producing two charm files.
3. We used `charm-binary-python-packages` which can cause problems (py310 vs py38) when built on 22.04 but running on 20.04. (It is still a mystery to me why juju chose to deploy it on 20.04 but at least that uncovered this issue.)

## Testing Instructions
Pack and deploy. Charm should not fail on the install hook :)


## Release Notes
Drop the `charm-binary-python-packages` section.
