### PR TITLE
insecure_skip_verify for localhost

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -722,6 +722,8 @@ class COSAgentRequirer(Object):
                         "metrics_path": job["path"],
                         "static_configs": [{"targets": [f"localhost:{job['port']}"]}],
                         # We include insecure_skip_verify because we are always scraping localhost.
+                        # Even if we have the certs for the scrape targets, we'd rather specify the scrape
+                        # jobs with localhost rather than the SAN DNS the cert was issued for.
                         "tls_config": {"insecure_skip_verify": True},
                     }
 

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -234,7 +234,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 6
+LIBPATCH = 7
 
 PYDEPS = ["cosl", "pydantic < 2"]
 
@@ -721,6 +721,8 @@ class COSAgentRequirer(Object):
                         "job_name": job["job_name"],
                         "metrics_path": job["path"],
                         "static_configs": [{"targets": [f"localhost:{job['port']}"]}],
+                        # We include insecure_skip_verify because we are always scraping localhost.
+                        "tls_config": {"insecure_skip_verify": True},
                     }
 
                 scrape_jobs.append(job)


### PR DESCRIPTION
## Issue
Fixes #211


## Solution
Always use insecure_skip_verify for localhost


## Testing Instructions
1. Deploy grafana-agent
2. relate over cos-agent (to zookeeper for example)
3. check that insecure_skip_verify is in /etc/grafana-agent.yaml


## Release Notes
Grafana-agent can now scrape TLS endpoints provided over cos-agent.
