### PR TITLE
increase snap client timeout to 20 seconds

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -658,7 +658,7 @@ class SnapClient:
         socket_path: str = "/run/snapd.socket",
         opener: Optional[urllib.request.OpenerDirector] = None,
         base_url: str = "http://localhost/v2/",
-        timeout: float = 5.0,
+        timeout: float = 20.0,
     ):
         """Initialize a client instance.
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Test flakiness caused frequently in CI environments where resources are limited

## Solution
<!-- A summary of the solution addressing the above issue -->

Increase snap client timeout to 20 seconds, seems to address the issue consistently for our case. Not sure if the observability team is happy to accept this patch or do something else instead. cc @sed-i

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

## Release Notes
<!-- A digestable summary of the change in this PR -->
