### PR TITLE
Split bases

### DIFF
--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   render:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
       - name: Render k8s Charm
         run: tox -e render-k8s
       - name: Pack Artifact
-        run: sudo apt-get update && sudo apt-get install tar && tar czvf artifact.tar.gz metadata.yaml src/charm.py
+        run: sudo apt-get update && sudo apt-get install tar && tar czvf artifact.tar.gz charmcraft.yaml metadata.yaml src/charm.py
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   render:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 venv/
 build/
 *.charm
+*.orig
 .coverage
 __pycache__/
 *.py[cod]
 .tox
 .idea/
 tests/integration/*-tester/lib/
+charmcraft.yaml
 metadata.yaml
 src/charm.py
 .env

--- a/k8s_charmcraft.yaml
+++ b/k8s_charmcraft.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+type: charm
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures: ["amd64"]
+    run-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures: ["amd64"]
+parts:
+  charm:
+    build-packages:
+    - git
+
+    # The following are needed for tls-certificates-interface
+    - build-essential
+    - python3-dev
+    - libffi-dev
+    - libssl-dev
+    - pkg-config
+    - rustc
+    - cargo

--- a/machine_charmcraft.yaml
+++ b/machine_charmcraft.yaml
@@ -5,14 +5,19 @@ type: charm
 bases:
   - build-on:
     - name: "ubuntu"
+      channel: "20.04"
+      architectures: ["amd64"]
+    run-on:
+    - name: "ubuntu"
+      channel: "20.04"
+      architectures: ["amd64"]
+  - build-on:
+    - name: "ubuntu"
       channel: "22.04"
       architectures: ["amd64"]
     run-on:
     - name: "ubuntu"
       channel: "22.04"
-      architectures: ["amd64"]
-    - name: "ubuntu"
-      channel: "20.04"
       architectures: ["amd64"]
 parts:
   charm:

--- a/tox.ini
+++ b/tox.ini
@@ -143,6 +143,7 @@ commands =
     # use a better solution when we actually have machine code
     cp {[vars]src_path}/k8s_charm.py {[vars]src_path}/charm.py
     cp k8s_metadata.yaml metadata.yaml
+    cp k8s_charmcraft.yaml charmcraft.yaml
 
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/integration
 
@@ -164,6 +165,7 @@ allowlist_externals = cp
 commands =
     cp {[vars]src_path}/machine_charm.py {[vars]src_path}/charm.py
     cp machine_metadata.yaml metadata.yaml
+    cp machine_charmcraft.yaml charmcraft.yaml
     pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/scenario/test_machine_charm --ignore {[vars]tst_path}/scenario/test_k8s
 
 [testenv:scenario-k8s]

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ allowlist_externals = cp
 commands =
     cp {toxinidir}/src/k8s_charm.py {toxinidir}/src/charm.py
     cp {toxinidir}/k8s_metadata.yaml {toxinidir}/metadata.yaml
+    cp {toxinidir}/k8s_charmcraft.yaml {toxinidir}/charmcraft.yaml
 
 [testenv:render-machine]
 skip_install=True
@@ -55,6 +56,7 @@ commands =
     cp {toxinidir}/src/machine_charm.py {toxinidir}/src/charm.py
     chmod +x {toxinidir}/src/charm.py
     cp {toxinidir}/machine_metadata.yaml {toxinidir}/metadata.yaml
+    cp {toxinidir}/machine_charmcraft.yaml {toxinidir}/charmcraft.yaml
 
 [testenv:lint]
 skip_install=True


### PR DESCRIPTION
## Issue
A 22.04-built charm does not work on 20.04 because libssl.so.3 isn't there.


## Solution
- [x] Machine: Split bases so we have 1:1 match between build-on and run-on.
- [x] K8s: Only use 22.04.
- [ ] Figure out how to upload two charm files to charmhub:
  - [ ] https://github.com/canonical/charmcraft/issues/1263

Fixes #245

Related:
- https://forum.snapcraft.io/t/solved-openssl-1-1-1/12122

## Testing
```bash
juju deploy --channel=edge ubuntu --base ubuntu@20.04
juju deploy ./grafana-agent_ubuntu-20.04-amd64.charm ga
juju relate ga ubuntu
```

