### PR TITLE
Convert gagent shared code to a charm lib

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -17,9 +17,10 @@ from charms.observability_libs.v1.kubernetes_service_patch import (
 )
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from cosl import GrafanaDashboard
-from grafana_agent import CONFIG_PATH, GrafanaAgentCharm
 from ops.main import main
 from ops.pebble import Layer
+
+from lib.charms.observability_libs.v0.grafana_agent import CONFIG_PATH, GrafanaAgentCharm
 
 logger = logging.getLogger(__name__)
 

--- a/tests/scenario/test_start_statuses.py
+++ b/tests/scenario/test_start_statuses.py
@@ -45,7 +45,7 @@ def _subp_run_mock(*a, **kw):
 def patch_all(substrate, placeholder_cfg_path):
     if substrate == "lxd":
         with patch("subprocess.run", _subp_run_mock), patch(
-            "grafana_agent.CONFIG_PATH", placeholder_cfg_path
+            "charms.observability_libs.v0.grafana_agent.CONFIG_PATH", placeholder_cfg_path
         ):
             yield
 

--- a/tests/unit/test_alerts.py
+++ b/tests/unit/test_alerts.py
@@ -99,13 +99,13 @@ LOKI_ALERT_RULES = {
 @patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestAlertIngestion(unittest.TestCase):
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
-    @patch("grafana_agent.GrafanaAgentCharm.charm_dir", pathlib.Path("/"))
-    @patch("grafana_agent.METRICS_RULES_SRC_PATH", tempfile.mkdtemp())
-    @patch("grafana_agent.METRICS_RULES_DEST_PATH", tempfile.mkdtemp())
-    @patch("grafana_agent.LOKI_RULES_SRC_PATH", tempfile.mkdtemp())
-    @patch("grafana_agent.LOKI_RULES_DEST_PATH", tempfile.mkdtemp())
-    @patch("grafana_agent.DASHBOARDS_SRC_PATH", tempfile.mkdtemp())
-    @patch("grafana_agent.DASHBOARDS_DEST_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.GrafanaAgentCharm.charm_dir", pathlib.Path("/"))
+    @patch("charms.observability_libs.v0.grafana_agent.METRICS_RULES_SRC_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.METRICS_RULES_DEST_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.LOKI_RULES_SRC_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.LOKI_RULES_DEST_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.DASHBOARDS_SRC_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.DASHBOARDS_DEST_PATH", tempfile.mkdtemp())
     @patch(
         "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
     )

--- a/tests/unit/test_scrape_configuration.py
+++ b/tests/unit/test_scrape_configuration.py
@@ -84,13 +84,13 @@ CERTS_RELATION_DATA = """[{"certificate": "-----BEGIN CERTIFICATE-----foobarcert
 @patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
 class TestScrapeConfiguration(unittest.TestCase):
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
-    @patch("grafana_agent.GrafanaAgentCharm.charm_dir", Path("/"))
-    @patch("grafana_agent.METRICS_RULES_SRC_PATH", tempfile.mkdtemp())
-    @patch("grafana_agent.METRICS_RULES_DEST_PATH", tempfile.mkdtemp())
-    @patch("grafana_agent.LOKI_RULES_SRC_PATH", tempfile.mkdtemp())
-    @patch("grafana_agent.LOKI_RULES_DEST_PATH", tempfile.mkdtemp())
-    @patch("grafana_agent.DASHBOARDS_SRC_PATH", tempfile.mkdtemp())
-    @patch("grafana_agent.DASHBOARDS_DEST_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.GrafanaAgentCharm.charm_dir", Path("/"))
+    @patch("charms.observability_libs.v0.grafana_agent.METRICS_RULES_SRC_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.METRICS_RULES_DEST_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.LOKI_RULES_SRC_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.LOKI_RULES_DEST_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.DASHBOARDS_SRC_PATH", tempfile.mkdtemp())
+    @patch("charms.observability_libs.v0.grafana_agent.DASHBOARDS_DEST_PATH", tempfile.mkdtemp())
     @patch(
         "charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True
     )


### PR DESCRIPTION
## Issue
After splitting the hybrid repo into this charm and the machine charm, we need to figure out how to prevent unnecessary code duplication between the two.


## Solution
Convert the shared code in `grafana_agent.py` to a charm lib.


## Context
NTA.


## Testing Instructions
CI.


## Release Notes
Convert gagent shared code to a charm lib.
