### PR TITLE
Fix typo in disk.rules

### DIFF
--- a/src/prometheus_alert_rules/disk.rules
+++ b/src/prometheus_alert_rules/disk.rules
@@ -4,7 +4,7 @@ groups:
   - record: used_disk_space
     expr: |
       100 * (1 - (
-        node_filesystem_free_bytes / node_filesystem_size_bytes_bytes)
+        node_filesystem_free_bytes / node_filesystem_size_bytes)
       )
   - alert: HostDiskSpaceFillsUp
     expr: predict_linear(used_disk_space{mountpoint=~"/"}[6h], 6*60*60) > 90


### PR DESCRIPTION
## Issue
The metric name `node_filesystem_size_bytes_bytes` appears to be incorrect due to typo. The correct metric name should be `node_filesystem_size_bytes`, and it can be verified from the [source code](https://github.com/prometheus/node_exporter/blob/master/collector/filesystem_common.go#L117) of node exporter.

This is a regression from #186 


## Solution
Fix the typo: `node_filesystem_size_bytes_bytes` -> `node_filesystem_size_bytes`

![Screenshot from 2023-09-26 12-30-20](https://github.com/canonical/grafana-agent-k8s-operator/assets/72372217/8f28edd4-3134-484a-9cfb-401a6a879b56)
![Screenshot from 2023-09-26 12-30-32](https://github.com/canonical/grafana-agent-k8s-operator/assets/72372217/038dbcdc-8c0b-4b36-b8b6-038e8a83b34c)

## Context
Prometheus alert rules

## Testing Instructions
N/A

## Release Notes
Fix typo in the Prometheus alert rules for disk
