### PR TITLE
Advertise content encoding

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -604,6 +604,9 @@ class GrafanaAgentCharm(CharmBase):
             loki_endpoints.append(
                 {
                     "url": self._cloud.loki_url,
+                    "headers": {
+                      "Content-Encoding": "snappy",
+                    },
                     "basic_auth": {
                         "username": self._cloud.credentials.username,
                         "password": self._cloud.credentials.password,


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

When using Grafana Agent with a logging backend other than Loki, we need to inform that backend about the payloads being compressed using snappy. Loki knows this is the case implicitly, but a third-party won't.


## Solution
<!-- A summary of the solution addressing the above issue -->
Add a `Content-Encoding` header to all outgoing requests.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This is useful when integrating with, for instance, Vector or Logstash, as they otherwise have no way of knowing about the encoding/compression. 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
Properly advertise snappy compression when using the cloud integrator