### PR TITLE
feat: Add arm64 support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,6 +11,14 @@ bases:
     - name: "ubuntu"
       channel: "22.04"
       architectures: ["amd64"]
+  - build-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures: ["arm64"]
+    run-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures: ["arm64"]
 parts:
   charm:
     build-packages:


### PR DESCRIPTION
## Issue
Makes the charm useable on arm64.


## Solution
Enables packing the charm on arm64.

## Context
I am testing Charmed 5G's Control Plane bundle on arm64, requiring the grafana-agent for observability.


## Testing Instructions
Can be tested by packing the charm on an arm64 machine (Raspberry Pi 4/5, Apple M1, etc.). It will require the OCI image to also be built for arm64: https://github.com/canonical/grafana-agent-rock/pull/29


## Release Notes
Added arm64 support
