### PR TITLE
Fix label treatment of related charms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .idea/
 tests/integration/*-tester/lib/
 .env
+cos-tool*

--- a/INTEGRATING.md
+++ b/INTEGRATING.md
@@ -75,13 +75,13 @@ requires:
 2. Obtain the library from charmhub:
 
 ```shell
-charmcraft fetch-lib charms.loki_k8s.v0.loki_push_api
+charmcraft fetch-lib charms.loki_k8s.v1.loki_push_api
 ```
 
 3. Import the library and use it in your `src/charm.py`:
 
 ```python
-from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
+from charms.loki_k8s.v1.loki_push_api import LogProxyConsumer
 ...
 
 class MyOperatorCharm(CharmBase):

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -32,3 +32,11 @@ parts:
     - pkg-config
     - rustc
     - cargo
+  cos-tool:
+    plugin: dump
+    source: .
+    build-packages:
+      - curl
+    override-pull: |
+      curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_TARGET_ARCH}
+      chmod +x cos-tool-*

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk
@@ -12,12 +12,16 @@ This document explains how to use the two principal objects this library provide
 implement the provider side of the `loki_push_api` relation interface. For instance, a Loki charm.
 The provider side of the relation represents the server side, to which logs are being pushed.
 
-- `LokiPushApiConsumer`: Used to obtain the loki api endpoint. This is useful for configuring
-  applications such as pebble, or charmed operators of workloads such as grafana-agent or promtail,
-  that can communicate with loki directly.
+- `LokiPushApiConsumer`: This object is meant to be used by any Charmed Operator that needs to
+send log to Loki by implementing the consumer side of the `loki_push_api` relation interface.
+For instance, a Promtail or Grafana agent charm which needs to send logs to Loki.
 
 - `LogProxyConsumer`: This object can be used by any Charmed Operator which needs to
 send telemetry, such as logs, to Loki through a Log Proxy by implementing the consumer side of the
+`loki_push_api` relation interface.
+
+- `LogForwarder`: This object can be used by any Charmed Operator which needs to send the workload
+standard output (stdout) through Pebble's log forwarding mechanism, to Loki endpoints through the
 `loki_push_api` relation interface.
 
 Filtering logs in Loki is largely performed on the basis of labels. In the Juju ecosystem, Juju
@@ -57,7 +61,7 @@ and three optional arguments.
   Subsequently, a Loki charm may instantiate the `LokiPushApiProvider` in its constructor as
   follows:
 
-      from charms.loki_k8s.v0.loki_push_api import LokiPushApiProvider
+      from charms.loki_k8s.v1.loki_push_api import LokiPushApiProvider
       from loki_server import LokiServer
       ...
 
@@ -163,7 +167,7 @@ instantiating it, typically in the constructor of your charm (the one which
 sends logs).
 
 ```python
-from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer
+from charms.loki_k8s.v1.loki_push_api import LokiPushApiConsumer
 
 class LokiClientCharm(CharmBase):
 
@@ -231,16 +235,23 @@ Adopting this object in a Charmed Operator consist of two steps:
    For example:
 
    ```python
-   from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
+   from charms.loki_k8s.v1.loki_push_api import LogProxyConsumer
 
    ...
 
        def __init__(self, *args):
            ...
            self._log_proxy = LogProxyConsumer(
-               charm=self, log_files=LOG_FILES, container_name=PEER, enable_syslog=True
+               self,
+               logs_scheme={
+                   "workload-a": {
+                       "log-files": ["/tmp/worload-a-1.log", "/tmp/worload-a-2.log"],
+                       "syslog-port": 1514,
+                   },
+                   "workload-b": {"log-files": ["/tmp/worload-b.log"], "syslog-port": 1515},
+               },
+               relation_name="log-proxy",
            )
-
            self.framework.observe(
                self._log_proxy.on.promtail_digest_error,
                self._promtail_error,
@@ -277,22 +288,9 @@ Adopting this object in a Charmed Operator consist of two steps:
 
    Note that:
 
-   - `LOG_FILES` is a `list` containing the log files we want to send to `Loki` or
-   `Grafana Agent`, for instance:
-
-   ```python
-   LOG_FILES = [
-       "/var/log/apache2/access.log",
-       "/var/log/alternatives.log",
-   ]
-   ```
-
-   - `container_name` is the name of the container in which the application is running.
-      If in the Pod there is only one container, this argument can be omitted.
-
    - You can configure your syslog software using `localhost` as the address and the method
-     `LogProxyConsumer.syslog_port` to get the port, or, alternatively, if you are using rsyslog
-     you may use the method `LogProxyConsumer.rsyslog_config()`.
+     `LogProxyConsumer.syslog_port("container_name")` to get the port, or, alternatively, if you are using rsyslog
+     you may use the method `LogProxyConsumer.rsyslog_config("container_name")`.
 
 2. Modify the `metadata.yaml` file to add:
 
@@ -354,6 +352,45 @@ These can be monitored via the PromtailDigestError events via:
        self.unit.status = BlockedStatus(event.message)
     )
 ```
+
+## LogForwarder class Usage
+
+Let's say that we have a charm's workload that writes logs to the standard output (stdout),
+and we need to send those logs to a workload implementing the `loki_push_api` interface,
+such as `Loki` or `Grafana Agent`. To know how to reach a Loki instance, a charm would
+typically use the `loki_push_api` interface.
+
+Use the `LogForwarder` class by instantiating it in the `__init__` method of the charm:
+
+```python
+from charms.loki_k8s.v1.loki_push_api import LogForwarder
+
+...
+
+  def __init__(self, *args):
+      ...
+      self._log_forwarder = LogForwarder(
+          self,
+          relation_name="logging"  # optional, defaults to `logging`
+      )
+```
+
+The `LogForwarder` by default will observe relation events on the `logging` endpoint and
+enable/disable log forwarding automatically.
+Next, modify the `metadata.yaml` file to add:
+
+The `log-forwarding` relation in the `requires` section:
+```yaml
+requires:
+ logging:
+   interface: loki_push_api
+   optional: true
+```
+
+Once the LogForwader class is implemented in your charm and the relation (implementing the
+`loki_push_api` interface) is active and healthy, the library will inject a Pebble layer in
+each workload container the charm has access to, to configure Pebble's log forwarding
+feature and start sending logs to Loki.
 
 ## Alerting Rules
 
@@ -451,7 +488,7 @@ from gzip import GzipFile
 from hashlib import sha256
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib import request
 from urllib.error import HTTPError
 
@@ -469,18 +506,19 @@ from ops.charm import (
     WorkloadEvent,
 )
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
+from ops.jujuversion import JujuVersion
 from ops.model import Container, ModelError, Relation
-from ops.pebble import APIError, ChangeError, PathError, ProtocolError
+from ops.pebble import APIError, ChangeError, Layer, PathError, ProtocolError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "bf76f23cdd03464b877c52bd1d2f563e"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 25
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 
@@ -513,8 +551,11 @@ WORKLOAD_CONFIG_PATH = "{}/{}".format(WORKLOAD_CONFIG_DIR, WORKLOAD_CONFIG_FILE_
 WORKLOAD_POSITIONS_PATH = "{}/positions.yaml".format(WORKLOAD_BINARY_DIR)
 WORKLOAD_SERVICE_NAME = "promtail"
 
-HTTP_LISTEN_PORT = 9080
-GRPC_LISTEN_PORT = 9095
+# These are the initial port values. As we can have more than one container,
+# we use odd and even numbers to avoid collisions.
+# Each new container adds 2 to the previous value.
+HTTP_LISTEN_PORT_START = 9080  # even start port
+GRPC_LISTEN_PORT_START = 9095  # odd start port
 
 
 class RelationNotFoundError(ValueError):
@@ -1677,20 +1718,6 @@ class ContainerNotFoundError(Exception):
         super().__init__(self.message)
 
 
-class MultipleContainersFoundError(Exception):
-    """Raised if no container name is passed but multiple containers are present."""
-
-    def __init__(self):
-        msg = (
-            "No 'container_name' parameter has been specified; since this Charmed Operator"
-            " is has multiple containers, container_name must be specified for the container"
-            " to get logs from."
-        )
-        self.message = msg
-
-        super().__init__(self.message)
-
-
 class PromtailDigestError(EventBase):
     """Event emitted when there is an error with Promtail initialization."""
 
@@ -1731,27 +1758,36 @@ class LogProxyConsumer(ConsumerBase):
     which traditionally log to syslog or do not have native Loki integration.
     The `LogProxyConsumer` can be instantiated as follows:
 
-        self._log_proxy_consumer = LogProxyConsumer(self, log_files=["/var/log/messages"])
+        self._log_proxy = LogProxyConsumer(
+            self,
+            logs_scheme={
+                "workload-a": {
+                    "log-files": ["/tmp/worload-a-1.log", "/tmp/worload-a-2.log"],
+                    "syslog-port": 1514,
+                },
+                "workload-b": {"log-files": ["/tmp/worload-b.log"], "syslog-port": 1515},
+            },
+            relation_name="log-proxy",
+        )
 
     Args:
         charm: a `CharmBase` object that manages this `LokiPushApiConsumer` object.
             Typically, this is `self` in the instantiating class.
-        log_files: a list of log files to monitor with Promtail.
+        logs_scheme: a dict which maps containers and a list of log files and syslog port.
         relation_name: the string name of the relation interface to look up.
             If `charm` has exactly one relation with this interface, the relation's
             name is returned. If none or multiple relations with the provided interface
             are found, this method will raise either a NoRelationWithInterfaceFoundError or
             MultipleRelationsWithInterfaceFoundError exception, respectively.
-        enable_syslog: Whether to enable syslog integration.
-        syslog_port: The port syslog is attached to.
+        containers_syslog_port: a dict which maps (and enable) containers and syslog port.
         alert_rules_path: an optional path for the location of alert rules
             files. Defaults to "./src/loki_alert_rules",
             resolved from the directory hosting the charm entry file.
             The alert rules are automatically updated on charm upgrade.
         recursive: Whether to scan for rule files recursively.
-        container_name: An optional container name to inject the payload into.
         promtail_resource_name: An optional promtail resource name from metadata
             if it has been modified and attached
+        insecure_skip_verify: skip SSL verification.
 
     Raises:
         RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -1769,36 +1805,22 @@ class LogProxyConsumer(ConsumerBase):
     def __init__(
         self,
         charm,
-        log_files: Optional[Union[List[str], str]] = None,
+        *,
+        logs_scheme=None,
         relation_name: str = DEFAULT_LOG_PROXY_RELATION_NAME,
-        enable_syslog: bool = False,
-        syslog_port: int = 1514,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
         recursive: bool = False,
-        container_name: str = "",
         promtail_resource_name: Optional[str] = None,
-        *,  # TODO: In v1, move the star up so everything after 'charm' is a kwarg
         insecure_skip_verify: bool = False,
     ):
         super().__init__(charm, relation_name, alert_rules_path, recursive)
         self._charm = charm
+        self._logs_scheme = logs_scheme or {}
         self._relation_name = relation_name
-        self._container = self._get_container(container_name)
-        self._container_name = self._get_container_name(container_name)
-
-        if not log_files:
-            log_files = []
-        elif isinstance(log_files, str):
-            log_files = [log_files]
-        elif not isinstance(log_files, list) or not all((isinstance(x, str) for x in log_files)):
-            raise TypeError("The 'log_files' argument must be a list of strings.")
-        self._log_files = log_files
-
-        self._syslog_port = syslog_port
-        self._is_syslog = enable_syslog
         self.topology = JujuTopology.from_charm(charm)
         self._promtail_resource_name = promtail_resource_name or "promtail-bin"
         self.insecure_skip_verify = insecure_skip_verify
+        self._promtails_ports = self._generate_promtails_ports(logs_scheme)
 
         # architecture used for promtail binary
         arch = platform.processor()
@@ -1808,23 +1830,26 @@ class LogProxyConsumer(ConsumerBase):
         self.framework.observe(events.relation_created, self._on_relation_created)
         self.framework.observe(events.relation_changed, self._on_relation_changed)
         self.framework.observe(events.relation_departed, self._on_relation_departed)
-        # turn the container name to a valid Python identifier
-        snake_case_container_name = self._container_name.replace("-", "_")
-        self.framework.observe(
-            getattr(self._charm.on, "{}_pebble_ready".format(snake_case_container_name)),
-            self._on_pebble_ready,
-        )
+        self._observe_pebble_ready()
 
-    def _on_pebble_ready(self, _: WorkloadEvent):
+    def _observe_pebble_ready(self):
+        for container in self._containers.keys():
+            snake_case_container_name = container.replace("-", "_")
+            self.framework.observe(
+                getattr(self._charm.on, f"{snake_case_container_name}_pebble_ready"),
+                self._on_pebble_ready,
+            )
+
+    def _on_pebble_ready(self, event: WorkloadEvent):
         """Event handler for `pebble_ready`."""
         if self.model.relations[self._relation_name]:
-            self._setup_promtail()
+            self._setup_promtail(event.workload)
 
     def _on_relation_created(self, _: RelationCreatedEvent) -> None:
         """Event handler for `relation_created`."""
-        if not self._container.can_connect():
-            return
-        self._setup_promtail()
+        for container in self._containers.values():
+            if container.can_connect():
+                self._setup_promtail(container)
 
     def _on_relation_changed(self, event: RelationEvent) -> None:
         """Event handler for `relation_changed`.
@@ -1846,26 +1871,27 @@ class LogProxyConsumer(ConsumerBase):
                 else:
                     self.on.alert_rule_status_changed.emit(valid=valid, errors=errors)
 
-        if not self._container.can_connect():
-            return
-        if self.model.relations[self._relation_name]:
-            if "promtail" not in self._container.get_plan().services:
-                self._setup_promtail()
-                return
+        for container in self._containers.values():
+            if not container.can_connect():
+                continue
+            if self.model.relations[self._relation_name]:
+                if "promtail" not in container.get_plan().services:
+                    self._setup_promtail(container)
+                    continue
 
-            new_config = self._promtail_config
-            if new_config != self._current_config:
-                self._container.push(
-                    WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config), make_dirs=True
-                )
+                new_config = self._promtail_config(container.name)
+                if new_config != self._current_config(container):
+                    container.push(
+                        WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config), make_dirs=True
+                    )
 
-            # Loki may send endpoints late. Don't necessarily start, there may be
-            # no clients
-            if new_config["clients"]:
-                self._container.restart(WORKLOAD_SERVICE_NAME)
-                self.on.log_proxy_endpoint_joined.emit()
-            else:
-                self.on.promtail_digest_error.emit("No promtail client endpoints available!")
+                # Loki may send endpoints late. Don't necessarily start, there may be
+                # no clients
+                if new_config["clients"]:
+                    container.restart(WORKLOAD_SERVICE_NAME)
+                    self.on.log_proxy_endpoint_joined.emit()
+                else:
+                    self.on.promtail_digest_error.emit("No promtail client endpoints available!")
 
     def _on_relation_departed(self, _: RelationEvent) -> None:
         """Event handler for `relation_departed`.
@@ -1873,106 +1899,52 @@ class LogProxyConsumer(ConsumerBase):
         Args:
             event: The event object `RelationDepartedEvent`.
         """
-        if not self._container.can_connect():
-            return
-        if not self._charm.model.relations[self._relation_name]:
-            self._container.stop(WORKLOAD_SERVICE_NAME)
-            return
+        for container in self._containers.values():
+            if not container.can_connect():
+                continue
+            if not self._charm.model.relations[self._relation_name]:
+                container.stop(WORKLOAD_SERVICE_NAME)
+                continue
 
-        new_config = self._promtail_config
-        if new_config != self._current_config:
-            self._container.push(WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config), make_dirs=True)
+            new_config = self._promtail_config(container.name)
+            if new_config != self._current_config(container):
+                container.push(WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config), make_dirs=True)
 
-        if new_config["clients"]:
-            self._container.restart(WORKLOAD_SERVICE_NAME)
-        else:
-            self._container.stop(WORKLOAD_SERVICE_NAME)
-        self.on.log_proxy_endpoint_departed.emit()
+            if new_config["clients"]:
+                container.restart(WORKLOAD_SERVICE_NAME)
+            else:
+                container.stop(WORKLOAD_SERVICE_NAME)
+            self.on.log_proxy_endpoint_departed.emit()
 
-    def _get_container(self, container_name: str = "") -> Container:  # pyright: ignore
-        """Gets a single container by name or using the only container running in the Pod.
-
-        If there is more than one container in the Pod a `PromtailDigestError` is emitted.
-
-        Args:
-            container_name: The container name.
-
-        Returns:
-            A `ops.model.Container` object representing the container.
-
-        Emits:
-            PromtailDigestError, if there was a problem obtaining a container.
-        """
-        try:
-            container_name = self._get_container_name(container_name)
-            return self._charm.unit.get_container(container_name)
-        except (MultipleContainersFoundError, ContainerNotFoundError, ModelError) as e:
-            msg = str(e)
-            logger.warning(msg)
-            self.on.promtail_digest_error.emit(msg)
-
-    def _get_container_name(self, container_name: str = "") -> str:
-        """Helper function for getting/validating a container name.
-
-        Args:
-            container_name: The container name to be validated (optional).
-
-        Returns:
-            container_name: The same container_name that was passed (if it exists) or the only
-            container name that is present (if no container_name was passed).
-
-        Raises:
-            ContainerNotFoundError, if container_name does not exist.
-            MultipleContainersFoundError, if container_name was not provided but multiple
-            containers are present.
-        """
-        containers = dict(self._charm.model.unit.containers)
-        if len(containers) == 0:
-            raise ContainerNotFoundError
-
-        if not container_name:
-            # container_name was not provided - will get it ourselves, if it is the only one
-            if len(containers) > 1:
-                raise MultipleContainersFoundError
-
-            # Get the first key in the containers' dict.
-            # Need to "cast", otherwise:
-            # error: Incompatible return value type (got "Optional[str]", expected "str")
-            container_name = cast(str, next(iter(containers.keys())))
-
-        elif container_name not in containers:
-            raise ContainerNotFoundError
-
-        return container_name
-
-    def _add_pebble_layer(self, workload_binary_path: str) -> None:
+    def _add_pebble_layer(self, workload_binary_path: str, container: Container) -> None:
         """Adds Pebble layer that manages Promtail service in Workload container.
 
         Args:
             workload_binary_path: string providing path to promtail binary in workload container.
+            container: container into which the layer is to be added.
         """
-        pebble_layer = {
-            "summary": "promtail layer",
-            "description": "pebble config layer for promtail",
-            "services": {
-                WORKLOAD_SERVICE_NAME: {
-                    "override": "replace",
-                    "summary": WORKLOAD_SERVICE_NAME,
-                    "command": "{} {}".format(workload_binary_path, self._cli_args),
-                    "startup": "disabled",
-                }
-            },
-        }
-        self._container.add_layer(
-            self._container_name, pebble_layer, combine=True  # pyright: ignore
+        pebble_layer = Layer(
+            {
+                "summary": "promtail layer",
+                "description": "pebble config layer for promtail",
+                "services": {
+                    WORKLOAD_SERVICE_NAME: {
+                        "override": "replace",
+                        "summary": WORKLOAD_SERVICE_NAME,
+                        "command": f"{workload_binary_path} {self._cli_args}",
+                        "startup": "disabled",
+                    }
+                },
+            }
         )
+        container.add_layer(container.name, pebble_layer, combine=True)
 
-    def _create_directories(self) -> None:
+    def _create_directories(self, container: Container) -> None:
         """Creates the directories for Promtail binary and config file."""
-        self._container.make_dir(path=WORKLOAD_BINARY_DIR, make_parents=True)
-        self._container.make_dir(path=WORKLOAD_CONFIG_DIR, make_parents=True)
+        container.make_dir(path=WORKLOAD_BINARY_DIR, make_parents=True)
+        container.make_dir(path=WORKLOAD_CONFIG_DIR, make_parents=True)
 
-    def _obtain_promtail(self, promtail_info: dict) -> None:
+    def _obtain_promtail(self, promtail_info: dict, container: Container) -> None:
         """Obtain promtail binary from an attached resource or download it.
 
         Args:
@@ -1981,33 +1953,31 @@ class LogProxyConsumer(ConsumerBase):
                - "filename": filename of promtail binary
                - "zipsha": sha256 sum of zip file of promtail binary
                - "binsha": sha256 sum of unpacked promtail binary
+            container: container into which promtail is to be obtained.
         """
         workload_binary_path = os.path.join(WORKLOAD_BINARY_DIR, promtail_info["filename"])
         if self._promtail_attached_as_resource:
-            self._push_promtail_if_attached(workload_binary_path)
+            self._push_promtail_if_attached(container, workload_binary_path)
             return
 
         if self._promtail_must_be_downloaded(promtail_info):
-            self._download_and_push_promtail_to_workload(promtail_info)
+            self._download_and_push_promtail_to_workload(container, promtail_info)
         else:
             binary_path = os.path.join(BINARY_DIR, promtail_info["filename"])
-            self._push_binary_to_workload(binary_path, workload_binary_path)
+            self._push_binary_to_workload(container, binary_path, workload_binary_path)
 
-    def _push_binary_to_workload(self, binary_path: str, workload_binary_path: str) -> None:
+    def _push_binary_to_workload(
+        self, container: Container, binary_path: str, workload_binary_path: str
+    ) -> None:
         """Push promtail binary into workload container.
 
         Args:
             binary_path: path in charm container from which promtail binary is read.
             workload_binary_path: path in workload container to which promtail binary is pushed.
+            container: container into which promtail is to be uploaded.
         """
         with open(binary_path, "rb") as f:
-            self._container.push(
-                workload_binary_path,
-                f,
-                permissions=0o755,
-                encoding=None,  # pyright: ignore
-                make_dirs=True,
-            )
+            container.push(workload_binary_path, f, permissions=0o755, make_dirs=True)
             logger.debug("The promtail binary file has been pushed to the workload container.")
 
     @property
@@ -2027,19 +1997,20 @@ class LogProxyConsumer(ConsumerBase):
                 return False
             raise
 
-    def _push_promtail_if_attached(self, workload_binary_path: str) -> bool:
+    def _push_promtail_if_attached(self, container: Container, workload_binary_path: str) -> bool:
         """Checks whether Promtail binary is attached to the charm or not.
 
         Args:
             workload_binary_path: string specifying expected path of promtail
                 in workload container
+            container: container into which promtail is to be pushed.
 
         Returns:
             a boolean representing whether Promtail binary is attached or not.
         """
         logger.info("Promtail binary file has been obtained from an attached resource.")
         resource_path = self._charm.model.resources.fetch(self._promtail_resource_name)
-        self._push_binary_to_workload(resource_path, workload_binary_path)
+        self._push_binary_to_workload(container, resource_path, workload_binary_path)
         return True
 
     def _promtail_must_be_downloaded(self, promtail_info: dict) -> bool:
@@ -2105,7 +2076,9 @@ class LogProxyConsumer(ConsumerBase):
         """
         return True if Path(binary_path).is_file() else False
 
-    def _download_and_push_promtail_to_workload(self, promtail_info: dict) -> None:
+    def _download_and_push_promtail_to_workload(
+        self, container: Container, promtail_info: dict
+    ) -> None:
         """Downloads a Promtail zip file and pushes the binary to the workload.
 
         Args:
@@ -2114,8 +2087,23 @@ class LogProxyConsumer(ConsumerBase):
                - "filename": filename of promtail binary
                - "zipsha": sha256 sum of zip file of promtail binary
                - "binsha": sha256 sum of unpacked promtail binary
+            container: container into which promtail is to be uploaded.
         """
-        with request.urlopen(promtail_info["url"]) as r:
+        # Check for Juju proxy variables and fall back to standard ones if not set
+        proxies: Optional[Dict[str, str]] = {}
+        if proxies and os.environ.get("JUJU_CHARM_HTTP_PROXY"):
+            proxies.update({"http": os.environ["JUJU_CHARM_HTTP_PROXY"]})
+        if proxies and os.environ.get("JUJU_CHARM_HTTPS_PROXY"):
+            proxies.update({"https": os.environ["JUJU_CHARM_HTTPS_PROXY"]})
+        if proxies and os.environ.get("JUJU_CHARM_NO_PROXY"):
+            proxies.update({"no_proxy": os.environ["JUJU_CHARM_NO_PROXY"]})
+        else:
+            proxies = None
+
+        proxy_handler = request.ProxyHandler(proxies)
+        opener = request.build_opener(proxy_handler)
+
+        with opener.open(promtail_info["url"]) as r:
             file_bytes = r.read()
             file_path = os.path.join(BINARY_DIR, promtail_info["filename"] + ".gz")
             with open(file_path, "wb") as f:
@@ -2132,7 +2120,7 @@ class LogProxyConsumer(ConsumerBase):
                 logger.debug("Promtail binary file has been downloaded.")
 
         workload_binary_path = os.path.join(WORKLOAD_BINARY_DIR, promtail_info["filename"])
-        self._push_binary_to_workload(binary_path, workload_binary_path)
+        self._push_binary_to_workload(container, binary_path, workload_binary_path)
 
     @property
     def _cli_args(self) -> str:
@@ -2143,18 +2131,17 @@ class LogProxyConsumer(ConsumerBase):
         """
         return "-config.file={}".format(WORKLOAD_CONFIG_PATH)
 
-    @property
-    def _current_config(self) -> dict:
+    def _current_config(self, container) -> dict:
         """Property that returns the current Promtail configuration.
 
         Returns:
             A dict containing Promtail configuration.
         """
-        if not self._container.can_connect():
+        if not container.can_connect():
             logger.debug("Could not connect to promtail container!")
             return {}
         try:
-            raw_current = self._container.pull(WORKLOAD_CONFIG_PATH).read()
+            raw_current = container.pull(WORKLOAD_CONFIG_PATH).read()
             return yaml.safe_load(raw_current)
         except (ProtocolError, PathError) as e:
             logger.warning(
@@ -2164,8 +2151,7 @@ class LogProxyConsumer(ConsumerBase):
             )
             return {}
 
-    @property
-    def _promtail_config(self) -> dict:
+    def _promtail_config(self, container_name: str) -> dict:
         """Generates the config file for Promtail.
 
         Reference: https://grafana.com/docs/loki/latest/send-data/promtail/configuration
@@ -2175,9 +2161,9 @@ class LogProxyConsumer(ConsumerBase):
             for client in config["clients"]:
                 client["tls_config"] = {"insecure_skip_verify": True}
 
-        config.update(self._server_config())
-        config.update(self._positions())
-        config.update(self._scrape_configs())
+        config.update(self._server_config(container_name))
+        config.update(self._positions)
+        config.update(self._scrape_configs(container_name))
         return config
 
     def _clients_list(self) -> list:
@@ -2188,7 +2174,7 @@ class LogProxyConsumer(ConsumerBase):
         """
         return self.loki_endpoints
 
-    def _server_config(self) -> dict:
+    def _server_config(self, container_name: str) -> dict:
         """Generates the server section of the Promtail config file.
 
         Returns:
@@ -2196,11 +2182,12 @@ class LogProxyConsumer(ConsumerBase):
         """
         return {
             "server": {
-                "http_listen_port": HTTP_LISTEN_PORT,
-                "grpc_listen_port": GRPC_LISTEN_PORT,
+                "http_listen_port": self._promtails_ports[container_name]["http_listen_port"],
+                "grpc_listen_port": self._promtails_ports[container_name]["grpc_listen_port"],
             }
         }
 
+    @property
     def _positions(self) -> dict:
         """Generates the positions section of the Promtail config file.
 
@@ -2209,19 +2196,20 @@ class LogProxyConsumer(ConsumerBase):
         """
         return {"positions": {"filename": WORKLOAD_POSITIONS_PATH}}
 
-    def _scrape_configs(self) -> dict:
+    def _scrape_configs(self, container_name: str) -> dict:
         """Generates the scrape_configs section of the Promtail config file.
 
         Returns:
             A dict representing the `scrape_configs` section.
         """
-        job_name = "juju_{}".format(self.topology.identifier)
+        job_name = f"juju_{self.topology.identifier}"
 
         # The new JujuTopology doesn't include unit, but LogProxyConsumer should have it
         common_labels = {
-            "juju_{}".format(k): v
+            f"juju_{k}": v
             for k, v in self.topology.as_dict(remapped_keys={"charm_name": "charm"}).items()
         }
+        common_labels["container"] = container_name
         scrape_configs = []
 
         # Files config
@@ -2235,12 +2223,13 @@ class LogProxyConsumer(ConsumerBase):
         config = {"targets": ["localhost"], "labels": labels}
         scrape_config = {
             "job_name": "system",
-            "static_configs": self._generate_static_configs(config),
+            "static_configs": self._generate_static_configs(config, container_name),
         }
         scrape_configs.append(scrape_config)
 
         # Syslog config
-        if self._is_syslog:
+        syslog_port = self._logs_scheme.get(container_name, {}).get("syslog-port")
+        if syslog_port:
             relabel_mappings = [
                 "severity",
                 "facility",
@@ -2250,16 +2239,16 @@ class LogProxyConsumer(ConsumerBase):
                 "msg_id",
             ]
             syslog_labels = common_labels.copy()
-            syslog_labels.update({"job": "{}_syslog".format(job_name)})
+            syslog_labels.update({"job": f"{job_name}_syslog"})
             syslog_config = {
                 "job_name": "syslog",
                 "syslog": {
-                    "listen_address": "127.0.0.1:{}".format(self._syslog_port),
+                    "listen_address": f"127.0.0.1:{syslog_port}",
                     "label_structured_data": True,
                     "labels": syslog_labels,
                 },
                 "relabel_configs": [
-                    {"source_labels": ["__syslog_message_{}".format(val)], "target_label": val}
+                    {"source_labels": [f"__syslog_message_{val}"], "target_label": val}
                     for val in relabel_mappings
                 ]
                 + [{"action": "labelmap", "regex": "__syslog_message_sd_(.+)"}],
@@ -2268,7 +2257,7 @@ class LogProxyConsumer(ConsumerBase):
 
         return {"scrape_configs": scrape_configs}
 
-    def _generate_static_configs(self, config: dict) -> list:
+    def _generate_static_configs(self, config: dict, container_name: str) -> list:
         """Generates static_configs section.
 
         Returns:
@@ -2276,14 +2265,14 @@ class LogProxyConsumer(ConsumerBase):
         """
         static_configs = []
 
-        for _file in self._log_files:
+        for _file in self._logs_scheme.get(container_name, {}).get("log-files", []):
             conf = deepcopy(config)
             conf["labels"]["__path__"] = _file
             static_configs.append(conf)
 
         return static_configs
 
-    def _setup_promtail(self) -> None:
+    def _setup_promtail(self, container: Container) -> None:
         # Use the first
         relations = self._charm.model.relations[self._relation_name]
         if len(relations) > 1:
@@ -2299,29 +2288,23 @@ class LogProxyConsumer(ConsumerBase):
         if not promtail_binaries:
             return
 
-        if not self._is_promtail_installed(promtail_binaries[self._arch]):
-            try:
-                self._obtain_promtail(promtail_binaries[self._arch])
-            except HTTPError as e:
-                msg = "Promtail binary couldn't be downloaded - {}".format(str(e))
-                logger.warning(msg)
-                self.on.promtail_digest_error.emit(msg)
-                return
+        self._create_directories(container)
+        self._ensure_promtail_binary(promtail_binaries, container)
+
+        container.push(
+            WORKLOAD_CONFIG_PATH,
+            yaml.safe_dump(self._promtail_config(container.name)),
+            make_dirs=True,
+        )
 
         workload_binary_path = os.path.join(
             WORKLOAD_BINARY_DIR, promtail_binaries[self._arch]["filename"]
         )
+        self._add_pebble_layer(workload_binary_path, container)
 
-        self._create_directories()
-        self._container.push(
-            WORKLOAD_CONFIG_PATH, yaml.safe_dump(self._promtail_config), make_dirs=True
-        )
-
-        self._add_pebble_layer(workload_binary_path)
-
-        if self._current_config.get("clients"):
+        if self._current_config(container).get("clients"):
             try:
-                self._container.restart(WORKLOAD_SERVICE_NAME)
+                container.restart(WORKLOAD_SERVICE_NAME)
             except ChangeError as e:
                 self.on.promtail_digest_error.emit(str(e))
             else:
@@ -2329,40 +2312,267 @@ class LogProxyConsumer(ConsumerBase):
         else:
             self.on.promtail_digest_error.emit("No promtail client endpoints available!")
 
-    def _is_promtail_installed(self, promtail_info: dict) -> bool:
+    def _ensure_promtail_binary(self, promtail_binaries: dict, container: Container):
+        if self._is_promtail_installed(promtail_binaries[self._arch], container):
+            return
+
+        try:
+            self._obtain_promtail(promtail_binaries[self._arch], container)
+        except HTTPError as e:
+            msg = f"Promtail binary couldn't be downloaded - {str(e)}"
+            logger.warning(msg)
+            self.on.promtail_digest_error.emit(msg)
+
+    def _is_promtail_installed(self, promtail_info: dict, container: Container) -> bool:
         """Determine if promtail has already been installed to the container.
 
         Args:
             promtail_info: dictionary containing information about promtail binary
                that must be used. The dictionary must at least contain a key
                "filename" giving the name of promtail binary
+            container: container in which to check whether promtail is installed.
         """
-        workload_binary_path = "{}/{}".format(WORKLOAD_BINARY_DIR, promtail_info["filename"])
+        workload_binary_path = f"{WORKLOAD_BINARY_DIR}/{promtail_info['filename']}"
         try:
-            self._container.list_files(workload_binary_path)
+            container.list_files(workload_binary_path)
         except (APIError, FileNotFoundError):
             return False
         return True
 
-    @property
-    def syslog_port(self) -> str:
-        """Gets the port on which promtail is listening for syslog.
+    def _generate_promtails_ports(self, logs_scheme) -> dict:
+        return {
+            container: {
+                "http_listen_port": HTTP_LISTEN_PORT_START + 2 * i,
+                "grpc_listen_port": GRPC_LISTEN_PORT_START + 2 * i,
+            }
+            for i, container in enumerate(logs_scheme.keys())
+        }
+
+    def syslog_port(self, container_name: str) -> str:
+        """Gets the port on which promtail is listening for syslog in this container.
 
         Returns:
             A str representing the port
         """
-        return str(self._syslog_port)
+        return str(self._logs_scheme.get(container_name, {}).get("syslog-port"))
 
-    @property
-    def rsyslog_config(self) -> str:
+    def rsyslog_config(self, container_name: str) -> str:
         """Generates a config line for use with rsyslog.
 
         Returns:
             The rsyslog config line as a string
         """
         return 'action(type="omfwd" protocol="tcp" target="127.0.0.1" port="{}" Template="RSYSLOG_SyslogProtocol23Format" TCP_Framing="octet-counted")'.format(
-            self._syslog_port
+            self._logs_scheme.get(container_name, {}).get("syslog-port")
         )
+
+    @property
+    def _containers(self) -> Dict[str, Container]:
+        return {cont: self._charm.unit.get_container(cont) for cont in self._logs_scheme.keys()}
+
+
+class _PebbleLogClient:
+    @staticmethod
+    def check_juju_version() -> bool:
+        """Make sure the Juju version supports Log Forwarding."""
+        juju_version = JujuVersion.from_environ()
+        if not juju_version > JujuVersion(version=str("3.3")):
+            msg = f"Juju version {juju_version} does not support Pebble log forwarding. Juju >= 3.4 is needed."
+            logger.warning(msg)
+            return False
+        return True
+
+    @staticmethod
+    def _build_log_target(
+        unit_name: str, loki_endpoint: str, topology: JujuTopology, enable: bool
+    ) -> Dict:
+        """Build a log target for the log forwarding Pebble layer.
+
+        Log target's syntax for enabling/disabling forwarding is explained here:
+        https://github.com/canonical/pebble?tab=readme-ov-file#log-forwarding
+        """
+        services_value = ["all"] if enable else ["-all"]
+
+        log_target = {
+            "override": "replace",
+            "services": services_value,
+            "type": "loki",
+            "location": loki_endpoint,
+        }
+        if enable:
+            log_target.update(
+                {
+                    "labels": {
+                        "product": "Juju",
+                        "charm": topology._charm_name,
+                        "juju_model": topology._model,
+                        "juju_model_uuid": topology._model_uuid,
+                        "juju_application": topology._application,
+                        "juju_unit": topology._unit,
+                    },
+                }
+            )
+
+        return {unit_name: log_target}
+
+    @staticmethod
+    def _build_log_targets(
+        loki_endpoints: Optional[Dict[str, str]], topology: JujuTopology, enable: bool
+    ):
+        """Build all the targets for the log forwarding Pebble layer."""
+        targets = {}
+        if not loki_endpoints:
+            return targets
+
+        for unit_name, endpoint in loki_endpoints.items():
+            targets.update(
+                _PebbleLogClient._build_log_target(
+                    unit_name=unit_name,
+                    loki_endpoint=endpoint,
+                    topology=topology,
+                    enable=enable,
+                )
+            )
+        return targets
+
+    @staticmethod
+    def disable_inactive_endpoints(
+        container: Container, active_endpoints: Dict[str, str], topology: JujuTopology
+    ):
+        """Disable forwarding for inactive endpoints by checking against the Pebble plan."""
+        pebble_layer = container.get_plan().to_dict().get("log-targets", None)
+        if not pebble_layer:
+            return
+
+        for unit_name, target in pebble_layer.items():
+            # If the layer is a disabled log forwarding endpoint, skip it
+            if "-all" in target["services"]:  # pyright: ignore
+                continue
+
+            if unit_name not in active_endpoints:
+                layer = Layer(
+                    {  # pyright: ignore
+                        "log-targets": _PebbleLogClient._build_log_targets(
+                            loki_endpoints={unit_name: "(removed)"},
+                            topology=topology,
+                            enable=False,
+                        )
+                    }
+                )
+                container.add_layer(f"{container.name}-log-forwarding", layer=layer, combine=True)
+
+    @staticmethod
+    def enable_endpoints(
+        container: Container, active_endpoints: Dict[str, str], topology: JujuTopology
+    ):
+        """Enable forwarding for the specified Loki endpoints."""
+        layer = Layer(
+            {  # pyright: ignore
+                "log-targets": _PebbleLogClient._build_log_targets(
+                    loki_endpoints=active_endpoints,
+                    topology=topology,
+                    enable=True,
+                )
+            }
+        )
+        container.add_layer(f"{container.name}-log-forwarding", layer, combine=True)
+
+
+class LogForwarder(ConsumerBase):
+    """Forward the standard outputs of all workloads operated by a charm to one or multiple Loki endpoints."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        *,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
+        recursive: bool = True,
+        skip_alert_topology_labeling: bool = False,
+    ):
+        _PebbleLogClient.check_juju_version()
+        super().__init__(
+            charm, relation_name, alert_rules_path, recursive, skip_alert_topology_labeling
+        )
+        self._charm = charm
+        self._relation_name = relation_name
+
+        on = self._charm.on[self._relation_name]
+        self.framework.observe(on.relation_joined, self._update_logging)
+        self.framework.observe(on.relation_changed, self._update_logging)
+        self.framework.observe(on.relation_departed, self._update_logging)
+        self.framework.observe(on.relation_broken, self._update_logging)
+
+    def _update_logging(self, _):
+        """Update the log forwarding to match the active Loki endpoints."""
+        loki_endpoints = {}
+
+        # Get the endpoints from relation data
+        for relation in self._charm.model.relations[self._relation_name]:
+            loki_endpoints.update(self._fetch_endpoints(relation))
+
+        if not loki_endpoints:
+            logger.warning("No Loki endpoints available")
+            return
+
+        for container in self._charm.unit.containers.values():
+            _PebbleLogClient.disable_inactive_endpoints(
+                container=container,
+                active_endpoints=loki_endpoints,
+                topology=self.topology,
+            )
+            _PebbleLogClient.enable_endpoints(
+                container=container, active_endpoints=loki_endpoints, topology=self.topology
+            )
+
+    def is_ready(self, relation: Optional[Relation] = None):
+        """Check if the relation is active and healthy."""
+        if not relation:
+            relations = self._charm.model.relations[self._relation_name]
+            if not relations:
+                return False
+            return all(self.is_ready(relation) for relation in relations)
+
+        try:
+            if self._extract_urls(relation):
+                return True
+            return False
+        except (KeyError, json.JSONDecodeError):
+            return False
+
+    def _extract_urls(self, relation: Relation) -> Dict[str, str]:
+        """Default getter function to extract Loki endpoints from a relation.
+
+        Returns:
+            A dictionary of remote units and the respective Loki endpoint.
+            {
+                "loki/0": "http://loki:3100/loki/api/v1/push",
+                "another-loki/0": "http://another-loki:3100/loki/api/v1/push",
+            }
+        """
+        endpoints: Dict = {}
+
+        for unit in relation.units:
+            endpoint = relation.data[unit]["endpoint"]
+            deserialized_endpoint = json.loads(endpoint)
+            url = deserialized_endpoint["url"]
+            endpoints[unit.name] = url
+
+        return endpoints
+
+    def _fetch_endpoints(self, relation: Relation) -> Dict[str, str]:
+        """Fetch Loki Push API endpoints from relation data using the endpoints getter."""
+        endpoints: Dict = {}
+
+        if not self.is_ready(relation):
+            logger.warning(f"The relation '{relation.name}' is not ready yet.")
+            return endpoints
+
+        # if the code gets here, the function won't raise anymore because it's
+        # also called in is_ready()
+        endpoints = self._extract_urls(relation)
+
+        return endpoints
 
 
 class CosTool:

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -518,7 +518,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -799,7 +799,11 @@ class AlertRules:
                         alert_rule["labels"] = {}
 
                     if self.topology:
-                        alert_rule["labels"].update(self.topology.label_matcher_dict)
+                        # only insert labels that do not already exist
+                        for label, val in self.topology.label_matcher_dict.items():
+                            if label not in alert_rule["labels"]:
+                                alert_rule["labels"][label] = val
+
                         # insert juju topology filters into a prometheus alert rule
                         # logql doesn't like empty matchers, so add a job matcher which hits
                         # any string as a "wildcard" which the topology labels will

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -286,7 +286,6 @@ from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import pkcs12
-from cryptography.x509.extensions import Extension, ExtensionNotFound
 from jsonschema import exceptions, validate  # type: ignore[import-untyped]
 from ops.charm import (
     CharmBase,
@@ -308,13 +307,13 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 21
+LIBPATCH = 25
 
 PYDEPS = ["cryptography", "jsonschema"]
 
 REQUIRER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v2/schemas/requirer.json",  # noqa: E501
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/tls_certificates/v1/schemas/requirer.json",
     "type": "object",
     "title": "`tls_certificates` requirer root schema",
     "description": "The `tls_certificates` root schema comprises the entire requirer databag for this interface.",  # noqa: E501
@@ -349,7 +348,7 @@ REQUIRER_JSON_SCHEMA = {
 
 PROVIDER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v2/schemas/provider.json",  # noqa: E501
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/tls_certificates/v1/schemas/provider.json",
     "type": "object",
     "title": "`tls_certificates` provider root schema",
     "description": "The `tls_certificates` root schema comprises the entire provider databag for this interface.",  # noqa: E501
@@ -623,6 +622,40 @@ def _load_relation_data(relation_data_content: RelationDataContent) -> dict:
     return certificate_data
 
 
+def _get_closest_future_time(
+    expiry_notification_time: datetime, expiry_time: datetime
+) -> datetime:
+    """Return expiry_notification_time if not in the past, otherwise return expiry_time.
+
+    Args:
+        expiry_notification_time (datetime): Notification time of impending expiration
+        expiry_time (datetime): Expiration time
+
+    Returns:
+        datetime: expiry_notification_time if not in the past, expiry_time otherwise
+    """
+    return (
+        expiry_notification_time if datetime.utcnow() < expiry_notification_time else expiry_time
+    )
+
+
+def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
+    """Extract expiry time from a certificate string.
+
+    Args:
+        certificate (str): x509 certificate as a string
+
+    Returns:
+        Optional[datetime]: Expiry datetime or None
+    """
+    try:
+        certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
+        return certificate_object.not_valid_after
+    except ValueError:
+        logger.warning("Could not load certificate.")
+        return None
+
+
 def generate_ca(
     private_key: bytes,
     subject: str,
@@ -645,7 +678,7 @@ def generate_ca(
     private_key_object = serialization.load_pem_private_key(
         private_key, password=private_key_password
     )
-    subject = issuer = x509.Name(
+    subject_name = x509.Name(
         [
             x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
             x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
@@ -668,8 +701,8 @@ def generate_ca(
     )
     cert = (
         x509.CertificateBuilder()
-        .subject_name(subject)
-        .issuer_name(issuer)
+        .subject_name(subject_name)
+        .issuer_name(subject_name)
         .public_key(private_key_object.public_key())  # type: ignore[arg-type]
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.utcnow())
@@ -905,9 +938,11 @@ def generate_private_key(
     key_bytes = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.BestAvailableEncryption(password)
-        if password
-        else serialization.NoEncryption(),
+        encryption_algorithm=(
+            serialization.BestAvailableEncryption(password)
+            if password
+            else serialization.NoEncryption()
+        ),
     )
     return key_bytes
 
@@ -982,6 +1017,38 @@ def generate_csr(
 
     signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
     return signed_certificate.public_bytes(serialization.Encoding.PEM)
+
+
+def csr_matches_certificate(csr: str, cert: str) -> bool:
+    """Check if a CSR matches a certificate.
+
+    Args:
+        csr (str): Certificate Signing Request as a string
+        cert (str): Certificate as a string
+    Returns:
+        bool: True/False depending on whether the CSR matches the certificate.
+    """
+    try:
+        csr_object = x509.load_pem_x509_csr(csr.encode("utf-8"))
+        cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
+
+        if csr_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ) != cert_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ):
+            return False
+        if (
+            csr_object.public_key().public_numbers().n  # type: ignore[union-attr]
+            != cert_object.public_key().public_numbers().n  # type: ignore[union-attr]
+        ):
+            return False
+    except ValueError:
+        logger.warning("Could not load certificate or CSR.")
+        return False
+    return True
 
 
 class CertificatesProviderCharmEvents(CharmEvents):
@@ -1447,7 +1514,7 @@ class TLSCertificatesRequiresV2(Object):
 
     @property
     def _requirer_csrs(self) -> List[Dict[str, Union[bool, str]]]:
-        """Returns list of requirer's CSRs from relation data.
+        """Returns list of requirer's CSRs from relation unit data.
 
         Example:
             [
@@ -1591,6 +1658,92 @@ class TLSCertificatesRequiresV2(Object):
             certificate_signing_request=new_certificate_signing_request
         )
         logger.info("Certificate renewal request completed.")
+
+    def get_assigned_certificates(self) -> List[Dict[str, str]]:
+        """Get a list of certificates that were assigned to this unit.
+
+        Returns:
+            List of certificates. For example:
+            [
+                {
+                    "ca": "-----BEGIN CERTIFICATE-----...",
+                    "chain": [
+                        "-----BEGIN CERTIFICATE-----..."
+                    ],
+                    "certificate": "-----BEGIN CERTIFICATE-----...",
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
+                }
+            ]
+        """
+        final_list = []
+        for csr in self.get_certificate_signing_requests(fulfilled_only=True):
+            assert isinstance(csr["certificate_signing_request"], str)
+            if cert := self._find_certificate_in_relation_data(csr["certificate_signing_request"]):
+                final_list.append(cert)
+        return final_list
+
+    def get_expiring_certificates(self) -> List[Dict[str, str]]:
+        """Get a list of certificates that were assigned to this unit that are expiring or expired.
+
+        Returns:
+            List of certificates. For example:
+            [
+                {
+                    "ca": "-----BEGIN CERTIFICATE-----...",
+                    "chain": [
+                        "-----BEGIN CERTIFICATE-----..."
+                    ],
+                    "certificate": "-----BEGIN CERTIFICATE-----...",
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
+                }
+            ]
+        """
+        final_list = []
+        for csr in self.get_certificate_signing_requests(fulfilled_only=True):
+            assert isinstance(csr["certificate_signing_request"], str)
+            if cert := self._find_certificate_in_relation_data(csr["certificate_signing_request"]):
+                expiry_time = _get_certificate_expiry_time(cert["certificate"])
+                if not expiry_time:
+                    continue
+                expiry_notification_time = expiry_time - timedelta(
+                    hours=self.expiry_notification_time
+                )
+                if datetime.utcnow() > expiry_notification_time:
+                    final_list.append(cert)
+        return final_list
+
+    def get_certificate_signing_requests(
+        self,
+        fulfilled_only: bool = False,
+        unfulfilled_only: bool = False,
+    ) -> List[Dict[str, Union[bool, str]]]:
+        """Gets the list of CSR's that were sent to the provider.
+
+        You can choose to get only the CSR's that have a certificate assigned or only the CSR's
+          that don't.
+
+        Args:
+            fulfilled_only (bool): This option will discard CSRs that don't have certificates yet.
+            unfulfilled_only (bool): This option will discard CSRs that have certificates signed.
+
+        Returns:
+            List of CSR dictionaries. For example:
+            [
+                {
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
+                    "ca": false
+                }
+            ]
+        """
+        final_list = []
+        for csr in self._requirer_csrs:
+            assert isinstance(csr["certificate_signing_request"], str)
+            cert = self._find_certificate_in_relation_data(csr["certificate_signing_request"])
+            if (unfulfilled_only and cert) or (fulfilled_only and not cert):
+                continue
+            final_list.append(csr)
+
+        return final_list
 
     @staticmethod
     def _relation_data_is_valid(certificates_data: dict) -> bool:
@@ -1802,71 +1955,3 @@ class TLSCertificatesRequiresV2(Object):
                     certificate=certificate_dict["certificate"],
                     expiry=expiry_time.isoformat(),
                 )
-
-
-def csr_matches_certificate(csr: str, cert: str) -> bool:
-    """Check if a CSR matches a certificate.
-
-    expects to get the original string representations.
-
-    Args:
-        csr (str): Certificate Signing Request
-        cert (str): Certificate
-    Returns:
-        bool: True/False depending on whether the CSR matches the certificate.
-    """
-    try:
-        csr_object = x509.load_pem_x509_csr(csr.encode("utf-8"))
-        cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
-
-        if csr_object.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ) != cert_object.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ):
-            return False
-        if (
-            csr_object.public_key().public_numbers().n  # type: ignore[union-attr]
-            != cert_object.public_key().public_numbers().n  # type: ignore[union-attr]
-        ):
-            return False
-    except ValueError:
-        logger.warning("Could not load certificate or CSR.")
-        return False
-    return True
-
-
-def _get_closest_future_time(
-    expiry_notification_time: datetime, expiry_time: datetime
-) -> datetime:
-    """Return expiry_notification_time if not in the past, otherwise return expiry_time.
-
-    Args:
-        expiry_notification_time (datetime): Notification time of impending expiration
-        expiry_time (datetime): Expiration time
-
-    Returns:
-        datetime: expiry_notification_time if not in the past, expiry_time otherwise
-    """
-    return (
-        expiry_notification_time if datetime.utcnow() < expiry_notification_time else expiry_time
-    )
-
-
-def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
-    """Extract expiry time from a certificate string.
-
-    Args:
-        certificate (str): x509 certificate as a string
-
-    Returns:
-        Optional[datetime]: Expiry datetime or None
-    """
-    try:
-        certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
-        return certificate_object.not_valid_after
-    except ValueError:
-        logger.warning("Could not load certificate.")
-        return None

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ import pathlib
 from typing import Any, Dict, List, Union
 
 import yaml
-from charms.loki_k8s.v0.loki_push_api import LokiPushApiProvider
+from charms.loki_k8s.v1.loki_push_api import LokiPushApiProvider
 from charms.observability_libs.v1.kubernetes_service_patch import (
     KubernetesServicePatch,
     ServicePort,

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -26,7 +26,7 @@ from charms.grafana_cloud_integrator.v0.cloud_config_requirer import (
     GrafanaCloudConfigRequirer,
 )
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
-from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer
+from charms.loki_k8s.v1.loki_push_api import LokiPushApiConsumer
 from charms.observability_libs.v0.cert_handler import CertHandler
 from charms.prometheus_k8s.v1.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,

--- a/tests/integration/loki-tester/src/charm.py
+++ b/tests/integration/loki-tester/src/charm.py
@@ -8,7 +8,7 @@ import logging
 from multiprocessing import Queue
 
 import logging_loki  # type: ignore
-from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer
+from charms.loki_k8s.v1.loki_push_api import LokiPushApiConsumer
 from charms.observability_libs.v0.juju_topology import JujuTopology
 from ops.charm import CharmBase
 from ops.main import main


### PR DESCRIPTION
## Issue
This charm overwrites existing topology labels with its own topology labels. This happens because:
1. This charm doesn't have cos-tool, so injection of label matchers is skipped.
2. This charm has an outdated labeling logic: here, all alert labels are being [replaced](https://github.com/canonical/grafana-agent-k8s-operator/blob/5955b98c3ced5f502a03b3ea9948dd4f0f4e1f2a/lib/charms/loki_k8s/v0/loki_push_api.py#L761) by this charm's labels, whereas in cos-lib [only missing labels are added](https://github.com/canonical/cos-lib/blob/486945531c3a95253c2ee3886204071b176e7841/src/cosl/rules.py#L298).
3. This charm has two different use cases for rules that are currently not captured well:
  1. Like most charms, this charm has built-in rules and dashboards that need to be enriched with the charm's topology labels.
  2. Like cos-config, this charm needs to forward 3rd-party rules and dashboards [without changing the labels](https://github.com/canonical/cos-configuration-k8s-operator/issues/44).

## Solution
- [x] Add cos-tool to charm.
- [x] Fetch lib loki_push_api.v1

Fixes #275.


## Context
This PR goes in tandem with:
- https://github.com/canonical/loki-k8s-operator/pull/353


## Testing Instructions
See https://github.com/canonical/loki-k8s-operator/pull/353.
```
Revision 61 of 'grafana-agent-k8s' released to edge/pr-277 (attaching resources: 'agent-image' r38)
```

## Upgrade Notes
No change further action beyond `juju refresh` is needed – labels should be corrected after an upgrade.
