### PR TITLE
Fix SSL Cert Issue in Certificate Transfer

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -249,7 +249,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         Args:
             cmd: Command to be run.
         """
-        self._container.exec(cmd)
+        self._container.exec(cmd).wait()
 
     @property
     def tracing_endpoint(self) -> Optional[str]:

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -80,7 +80,7 @@ class GrafanaAgentCharm(CharmBase):
     _cert_path = "/tmp/agent/grafana-agent.pem"
     _key_path = "/tmp/agent/grafana-agent.key"
     _ca_path = "/usr/local/share/ca-certificates/grafana-agent-operator.crt"
-    _ca_folder_path = "/usr/loca/share/ca-certificates"
+    _ca_folder_path = "/usr/local/share/ca-certificates"
 
     # Pairs of (incoming, [outgoing]) relation names. If any 'incoming' is joined without at least
     # one matching 'outgoing', the charm will block. Without any matching outgoing relation we may


### PR DESCRIPTION
## Issue
Complementary to the fix of https://github.com/canonical/loki-k8s-operator/issues/360


## Solution
This PR points the `_ca_folder_path` to the correct path to solve the `certificate signed by unknown authority issue` when `gagent` is related over the `certificate_transfer` interface
