### PR TITLE
Update dashboards when relation broken

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -88,6 +88,10 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
             self.on["grafana-dashboards-consumer"].relation_changed,
             self._on_dashboards_changed,
         )
+        self.framework.observe(
+            self.on["grafana-dashboards-consumer"].relation_broken,
+            self._on_dashboards_changed,
+        )
 
         self.framework.observe(
             self.on.agent_pebble_ready,  # pyright: ignore


### PR DESCRIPTION
Previously, when the relation between grafana-agent and a charm providing a dashboard
(over the grafana-dashboards-consumer relation)
was broken, the dashboards would not be removed.
This fixes that issue, by also running the dashboards changed method when the relation is broken.

## Testing Instructions

- Deploy grafana, grafana-agent-k8s, and a charm that provides a dashboard.
- verify that the dashboards are visible in the grafana web ui
- remove the relation between grafana-agent-k8s and the charm that provides a dashboard
- verify that the dashboards are no longer visible in the grafana web ui.  These dashboards should also be removed from `/var/lib/juju/agents/unit-grafana-agent-0/charm/grafana_dashboards/` in grafana-agent-k8s.