### PR TITLE
fix: use set_ports instead of open_port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -55,8 +55,7 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
     def __init__(self, *args):
         super().__init__(*args)
         self._container = self.unit.get_container(self._name)
-        self.unit.open_port(protocol="tcp", port=self._http_listen_port)
-        self.unit.open_port(protocol="tcp", port=self._grpc_listen_port)
+        self.unit.set_ports(self._http_listen_port, self._grpc_listen_port)
 
         self._scrape = MetricsEndpointConsumer(self)
         self.framework.observe(


### PR DESCRIPTION
## Issue

`open_port` doesn't close ports; if the port changes on upgrades, the previous one isn't closed.

## Solution

Use `set_ports` instead, as documented [here](https://github.com/canonical/operator/blob/ab239e1156bd206f9825b5be96fbf83121489fee/ops/model.py#L699).