### PR TITLE
bump grafana-agent container image to 0.40.4-22.04_stable

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,7 +33,7 @@ containers:
 resources:
   agent-image:
     type: oci-image
-    upstream-source: ubuntu/grafana-agent:0.35.2-22.04_stable
+    upstream-source: ubuntu/grafana-agent:0.40.2-22.04_stable
     description: OCI image for Grafana Agent
 
 requires:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,7 +33,7 @@ containers:
 resources:
   agent-image:
     type: oci-image
-    upstream-source: ubuntu/grafana-agent:0.40.2-22.04_stable
+    upstream-source: ubuntu/grafana-agent:0.40.4-22.04_stable
     description: OCI image for Grafana Agent
 
 requires:

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ description = Check code against coding style standards
 deps =
     black
     ruff
-    codespell
+    codespell<2.3.0 # https://github.com/codespell-project/codespell/issues/3430
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache --skip *.svg
     ruff {[vars]all_path}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Contributes to #296.  That issue is affected by a [hard to reproduce upstream bug](https://github.com/prometheus/prometheus/issues/11589) that may have been fixed in 0.36.  

## Solution
<!-- A summary of the solution addressing the above issue -->
Bumps the grafana-agent container image

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
grafana-agent may include breaking changes in minor version bumps.  I've scanned through the release notes between 0.35 (current version) and 0.40.5 (latest), but I don't have enough background context to really catch anything that affects us.  When reviewing, please also read through this summary of breaking changes and highlight anything that matters:

  * [v0.40.5](https://github.com/grafana/agent/releases/tag/v0.40.5)
    * some `pg_stat_*` metrics were changed because `prometheus.exporter.postgres` was updated.  
  * [v0.40.0](https://github.com/grafana/agent/releases/tag/v0.40.0)
    * "Prohibit the configuration of services within modules"?
  * [v0.39.0](https://github.com/grafana/agent/releases/tag/v0.39.0)
    * (I dont think these are relevant, but don't know for sure)
      * otelcol.receiver.prometheus will drop all otel_scope_info metrics when converting them to OTLP.
      * The target block in prometheus.exporter.blackbox requires a mandatory name argument instead of a block label

  * [v0.37.1](https://github.com/grafana/agent/releases/tag/v0.37.1)
    * seeveral breaking changes - see link

  * [v0.36.0](https://github.com/grafana/agent/releases/tag/v0.36.0)
    * loki.source.file component will no longer automatically detect and decompress logs from compressed files. A new configuration block is available to enable decompression explicitly. See the [upgrade guide][] for migration instructions. (@thampiotr)
    * otelcol.exporter.prometheus: Set include_scope_info to false by default. You can set it to true to preserve previous behavior. (@gouthamve)
    * prometheus.remote_write: Set retry_on_http_429 to true by default in the queue_config block.You can set it to false to preserve previous behavior. (@wildum)
