### PR TITLE
Add codespell dictionary settings to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
+[tool.codespell]
+skip = ".git,.tox,build,lib,venv*,.mypy_cache"
+ignore-words-list = "assertIn"
+
 # Linting tools configuration
 [tool.ruff]
 line-length = 99

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ description = Check code against coding style standards
 deps =
     black
     ruff
-    codespell<2.3.0 # https://github.com/codespell-project/codespell/issues/3430
+    codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache --skip *.svg
     ruff {[vars]all_path}


### PR DESCRIPTION
## Issue
codespell 2.3 introduces changes that raises "assertIn" as a spelling mistake. 

## Solution
Add "assertIn" to codespell's dictionary and unpin codespell

## Testing Instructions
CI coverage handles this.  If it passes linting, it works.