### PR TITLE
update cloud_config_requirer lib

### DIFF
--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -6,7 +6,7 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "e6f580481c1b4388aa4d2cdf412a47fa"
 LIBAPI = 0
-LIBPATCH = 6
+LIBPATCH = 7
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 
@@ -57,7 +57,7 @@ class GrafanaCloudConfigRequirer(Object):
 
     def _on_relation_broken(self, event):
         self.on.cloud_config_revoked.emit()  # pyright: ignore
-    
+
     def _is_not_empty(self, s):
         return bool(s and not s.isspace())
 
@@ -83,16 +83,8 @@ class GrafanaCloudConfigRequirer(Object):
     @property
     def credentials(self):
         """Return the credentials, if any; otherwise, return None."""
-        if not all(
-            self._is_not_empty(x)
-            for x in [
-                self._data.get("username", ""),
-                self._data.get("password", ""),
-            ]):
-                return Credentials(
-                    self._data.get("username", ""),
-                    self._data.get("password", "")
-                )
+        if (username := self._data.get("username", "").strip()) and (password := self._data.get("password", "").strip()):
+            return Credentials(username, password)
         return None
 
     @property
@@ -124,7 +116,7 @@ class GrafanaCloudConfigRequirer(Object):
         """Return the prometheus endpoint dict."""
         if not self.prometheus_ready:
             return {}
-        
+
         endpoint = {}
         endpoint["url"] = self.prometheus_url
         if self.credentials:

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,8 @@ deps =
     asyncstdlib
     # Libjuju needs to track the juju version
     juju ~= 3.1.0
+    # https://github.com/juju/python-libjuju/issues/1184
+    websockets<14.0
     pytest
     prometheus-api-client
     pytest-operator


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR updates the `cloud_config_requirer` lib to its last version, so [we can fix this same issue](https://github.com/canonical/grafana-agent-operator/issues/203), but in the k8s operator

> We are not updating the others libs in this PR, since we are addressing it in a separate PR because [it needs modification to charm code](https://github.com/canonical/grafana-agent-k8s-operator/issues/328).


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Pack the charm, and deploy this bundle:

```yaml
bundle: kubernetes
applications:
  agent:
    charm: local:grafana-agent-k8s-0
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  flog:
    charm: flog-k8s
    channel: latest/edge
    revision: 8
    base: ubuntu@20.04/stable
    resources:
      workload-image: 2
    scale: 1
    constraints: arch=amd64
  gci:
    charm: grafana-cloud-integrator
    channel: latest/edge
    revision: 23
    scale: 1
    options:
      loki-url: http://loki.com
      password: Password
      username: Username
    constraints: arch=amd64
  loki:
    charm: loki-k8s
    channel: latest/edge
    revision: 176
    base: ubuntu@20.04/stable
    resources:
      loki-image: 100
      node-exporter-image: 3
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
relations:
- - gci:grafana-cloud-config
  - agent:grafana-cloud-config
- - flog:log-proxy
  - agent:logging-provider
- - agent:logging-consumer
  - loki:logging
```



then, verify that in every `grafana-agent` config file, `username` and `password` are inside `logs` section, for instance:

```yaml
logs:
  configs:
  - clients:
    - tls_config:
        insecure_skip_verify: false
      url: http://loki-0.loki-endpoints.test.svc.cluster.local:3100/loki/api/v1/push
    - basic_auth:
        password: Password
        username: Username
      headers:
        Content-Encoding: snappy
      tls_config:
        insecure_skip_verify: false
      url: http://loki.com
    name: push_api_server
    scrape_configs:
    - job_name: loki
      loki_push_api:
        server:
          grpc_listen_port: 3600
          http_listen_port: 3500
  positions_directory: /run/grafana-agent-positions
```
