### PR TITLE
feat: support external ca from cloud-integrator

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -92,6 +92,7 @@ class GrafanaAgentCharm(CharmBase):
     _key_path = "/tmp/agent/grafana-agent.key"
     _ca_path = "/usr/local/share/ca-certificates/grafana-agent-operator.crt"
     _ca_folder_path = "/usr/local/share/ca-certificates"
+    _cloud_ca_path = "/usr/local/share/ca-certificates/cloud-integrator.crt"
 
     # mapping from tempo-supported receivers to the receiver ports to be opened on the grafana-agent host
     _tracing_receivers_ports: Dict[ReceiverProtocol, int] = {
@@ -349,6 +350,12 @@ class GrafanaAgentCharm(CharmBase):
 
     def _on_cloud_config_available(self, _) -> None:
         logger.info("cloud config available")
+        # Write CA from cloud config
+        if self._cloud.tls_ca_ready:
+            self.write_file(self._cloud_ca_path, self._cloud.tls_ca)
+        else:
+            self._delete_file_if_exists(self._cloud_ca_path)
+        self.run(["update-ca-certificates", "--fresh"])
         self._update_config()
         self._update_tracing_provider()
 
@@ -1034,7 +1041,7 @@ class GrafanaAgentCharm(CharmBase):
             a dict with Loki config
         """
         configs = []
-        if self._loki_consumer.loki_endpoints:
+        if self._loki_consumer.loki_endpoints or self._cloud.loki_ready:
             configs.append(
                 {
                     "name": "push_api_server",

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -92,6 +92,7 @@ class GrafanaAgentCharm(CharmBase):
     _key_path = "/tmp/agent/grafana-agent.key"
     _ca_path = "/usr/local/share/ca-certificates/grafana-agent-operator.crt"
     _ca_folder_path = "/usr/local/share/ca-certificates"
+    # We have a `limit: 1` on the cloud integrator relation so we expect only one such cert.
     _cloud_ca_path = "/usr/local/share/ca-certificates/cloud-integrator.crt"
 
     # mapping from tempo-supported receivers to the receiver ports to be opened on the grafana-agent host


### PR DESCRIPTION
## Issue
This PR partially is in tandem with the PR https://github.com/canonical/grafana-cloud-integrator/pull/21 and should be merged after.

It also fixes (partially) https://github.com/canonical/grafana-cloud-integrator/issues/18 (I'm also opening a PR in the machine charm).

⚠️ Do NOT merge before the other one, it contains the (yet) unreleased version of the `cloud_config_requirer` library.

## Solution

**grafana-cloud-integrator#21** (the PR for the CA issue) is addressed by saving the CA coming from relation data to file, and then calling `update-ca-certificates` as usual. We do this on the custom `cloud-config-available` event, which is emitted whenever there is a relation joined/changed/broken involving the cloud-integrator relation.

**grafana-cloud-integrator#18** (the config issue) is solved by populating the `_loki_config` not only if there are endpoints coming from `self._loki_consumer`, but also considering the ones coming from the cloud integrator (`self._cloud.loki_ready`). The endpoints themselves are already included in `self._loki_endpoints_with_tls()`.

## Testing Instructions
Remember to use the Loki FQDN, not the IP, or TLS won't work.

1. Deploy the necessary charms:
```bash
# all the juju deploy commands are from edge and with --trust
juju deploy (the grafana-agent-k8s charm from this branch) agent
juju deploy (the grafana-cloud-integrator from the linked PR) cloud-integrator
juju deploy self-signed-certificates ca
juju deploy flog-k8s flog
juju deploy loki-k8s loki
```
2. Relate the charms:
```bash
juju relate agent:logging-provider flog:log-proxy
juju relate agent cloud-integrator
juju relate loki ca
```
3. `juju config cloud-integrator loki-url="https://<loki-fqdn>:3100/loki/api/v1/push"`
4. Make sure there is no `agent` series in Loki (no CA is configured in cloud-integrator yet)
```bash
curl -k https://<loki-fqdn>:3100/loki/api/v1/series | jq | grep flog
```
5. Extract the CA from Loki and set it in cloud integrator:
```bash
juju scp --container=loki loki/0:/usr/local/share/ca-certificates/cos-ca.crt cos-ca.crt
juju config cloud-integrator tls-ca=@cos-ca.crt
```
6. Observe the configuration contains the Loki endpoint, the CA has reached grafana-agent and that the series is now in Loki:
```bash
# agent config contains the endpoint
juju ssh --container=agent agent/0 cat /etc/grafana-agent.yaml
# agent contains the certificate from cloud-integrator
juju ssh --container=agent agent/0 cat /usr/local/share/ca-certificates/cloud-integrator.crt
# series is now in loki
curl -k https://<loki-fqdn>:3100/loki/api/v1/series | jq | grep flog
```
