### PR TITLE
Rename the title of the node-exporter dashboard

### DIFF
--- a/src/grafana_dashboards/node-exporter-full.json
+++ b/src/grafana_dashboards/node-exporter-full.json
@@ -23194,7 +23194,7 @@
   },
   "timezone": "browser",
   "title": "System Resources (container)",
-  "uid": "rYdddlPWk",
+  "uid": "rYdddlPWk-1",
   "version": 10,
   "weekStart": ""
 }

--- a/src/grafana_dashboards/node-exporter-full.json
+++ b/src/grafana_dashboards/node-exporter-full.json
@@ -23195,6 +23195,6 @@
   "timezone": "browser",
   "title": "System Resources (container)",
   "uid": "rYdddlPWk",
-  "version": 9,
+  "version": 10,
   "weekStart": ""
 }

--- a/src/grafana_dashboards/node-exporter-full.json
+++ b/src/grafana_dashboards/node-exporter-full.json
@@ -23193,7 +23193,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "System Resources",
+  "title": "System Resources (container)",
   "uid": "rYdddlPWk",
   "version": 9,
   "weekStart": ""


### PR DESCRIPTION


## Issue
<!-- What issue is this PR trying to solve? -->
There is a dashboard title collision with the one in the grafana-agent machine charm.

## Solution
<!-- A summary of the solution addressing the above issue -->
Rename the title as suggested in https://github.com/canonical/observability/pull/206/files#r1863947198
uid collision will be addressed later as indicated in https://github.com/canonical/observability/pull/206.


