### PR TITLE
Replace GrafanaDashboard with LZMABase64

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # FIXME: Packing the charm with 2.2.0+139.gd011d92 will not include dependencies in PYDEPS key:
 # https://chat.charmhub.io/charmhub/pl/wngp665ycjnb78ar9ojrfhxjkr
 # That's why we are including cosl here until the bug in charmcraft is solved
-cosl >= 0.0.19
+cosl >= 0.0.50
 ops >= 2.5.0
 pydantic < 2
 requests

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,7 +13,7 @@ import yaml
 from charms.loki_k8s.v1.loki_push_api import LokiPushApiProvider
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
-from cosl import GrafanaDashboard
+from cosl import LZMABase64
 from ops.main import main
 from ops.pebble import Layer
 
@@ -32,7 +32,7 @@ SCRAPE_RELATION_NAME = "metrics-endpoint"
         GrafanaAgentCharm,
         LokiPushApiProvider,
         MetricsEndpointConsumer,
-        GrafanaDashboard,
+        LZMABase64,
     ),
 )
 class GrafanaAgentK8sCharm(GrafanaAgentCharm):
@@ -156,9 +156,9 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
             if "templates" not in dashboards:
                 continue
             for template in dashboards["templates"]:
-                content = GrafanaDashboard(
+                content = json.loads(LZMABase64.decompress(
                     dashboards["templates"][template].get("content")
-                )._deserialize()
+                ))
                 entry = {
                     "charm": dashboards["templates"][template].get("charm", "charm_name"),
                     "relation_id": rel.id,

--- a/src/charm.py
+++ b/src/charm.py
@@ -156,9 +156,9 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
             if "templates" not in dashboards:
                 continue
             for template in dashboards["templates"]:
-                content = json.loads(LZMABase64.decompress(
-                    dashboards["templates"][template].get("content")
-                ))
+                content = json.loads(
+                    LZMABase64.decompress(dashboards["templates"][template].get("content"))
+                )
                 entry = {
                     "charm": dashboards["templates"][template].get("charm", "charm_name"),
                     "relation_id": rel.id,

--- a/tests/scenario/test_dashboard_transfer.py
+++ b/tests/scenario/test_dashboard_transfer.py
@@ -2,12 +2,12 @@
 # See LICENSE file for licensing details.
 import json
 
-from cosl import GrafanaDashboard
+from cosl import LZMABase64
 from ops.testing import Container, Relation, State
 
 
 def encode_as_dashboard(dct: dict):
-    return GrafanaDashboard._serialize(json.dumps(dct).encode("utf-8"))
+    return LZMABase64.compress(json.dumps(dct))
 
 
 def test_dashboard_propagation(ctx):

--- a/tests/scenario/test_dashboard_transfer.py
+++ b/tests/scenario/test_dashboard_transfer.py
@@ -42,4 +42,4 @@ def test_dashboard_propagation(ctx):
         dash = mgr.charm.dashboards[0]
         assert dash["charm"] == expected["charm"]
         assert dash["title"] == expected["title"]
-        assert dash["content"] == expected["content"]._deserialize()
+        assert dash["content"] == json.loads(LZMABase64.decompress(expected["content"]))


### PR DESCRIPTION
## Issue
Charm code use deprecated class from cos-lib.

## Solution
Refactor to use LZMABase64 instead of the deprecated GrafanaDashboard.

In tandem with:
- https://github.com/canonical/cos-lib/pull/114
- https://github.com/canonical/grafana-k8s-operator/pull/363
- https://github.com/canonical/grafana-agent-operator/pull/224
