### PR TITLE
Return empty receivers list if tracing backend isn't connected

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -288,6 +288,8 @@ class GrafanaAgentCharm(CharmBase):
         )
 
     def _update_tracing_provider(self):
+        # If the "upstream" tracing is not ready, we don't want to publish the receivers.
+        # Otherwise, charms that integrate over `tracing` would start sending traces to an endpoint that isn't open.
         requested_tracing_protocols = (
             self._requested_tracing_protocols if self._tracing.is_ready() else []
         )
@@ -884,8 +886,6 @@ class GrafanaAgentCharm(CharmBase):
             a dict with the receivers config.
         """
         if not self._tracing.is_ready():
-            # we need to guard against the "upstream" tracing backend relation as grafana-agent fails to start
-            # if we don't provide the tracing endpoint to send data to.
             logger.warning(
                 "Tracing backend is not connected yet: grafana-agent cannot ingest traces."
             )


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
When a tracing backend isn't connected, grafana-agent errors out due to a missing guard. Also, when the guard is added, the same issue as in https://github.com/canonical/grafana-agent-operator/issues/219 appears.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add the same guard as in the machine charm. Also return an empty receivers list if the upstream tracing backend isn't ready yet.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Deploy the following bundle:
```
bundle: kubernetes
applications:
  grafana-agent-k8s:
    charm: local:grafana-agent-k8s-2
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
  postgresql-k8s:
    charm: postgresql-k8s
    channel: 14/edge
    revision: 470
    resources:
      postgresql-image: 164
    scale: 1
    constraints: arch=amd64
    storage:
      pgdata: kubernetes,1,1024M
    trust: true
relations:
- - postgresql-k8s:tracing
  - grafana-agent-k8s:tracing-provider
```

Observe that neither of the charms errors out or shows pydantic validation errors once the relation settles. At this moment, postgres is expected to throw this error:
```
unit-postgresql-k8s-0: 15:33:21 ERROR unit.postgresql-k8s/0.juju-log no receiver found with protocol='otlp_http'
```

This should become a warning once https://github.com/canonical/tempo-coordinator-k8s-operator/pull/95 is merged and the library gets updated.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
