### PR TITLE
fix: deduplicate remote_write addresses to avoid crashes

### DIFF
--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -691,9 +691,7 @@ class GrafanaAgentCharm(CharmBase):
     def _on_dashboard_status_changed(self, _event=None):
         """Re-initialize dashboards to forward."""
         # TODO: add constructor arg for `inject_dropdowns=False` instead of 'private' method?
-        self._grafana_dashboards_provider._reinitialize_dashboard_data(
-            inject_dropdowns=False
-        )  # noqa
+        self._grafana_dashboards_provider._reinitialize_dashboard_data(inject_dropdowns=False)  # noqa
         self._update_status()
 
     def _enhance_endpoints_with_tls(self, endpoints) -> List[Dict[str, Any]]:
@@ -702,6 +700,19 @@ class GrafanaAgentCharm(CharmBase):
                 "insecure_skip_verify": self.model.config.get("tls_insecure_skip_verify")
             }
         return endpoints
+
+    def _deduplicate_endpoints(self, endpoints: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Deduplicate endpoints based on their URL."""
+        seen_urls = set()
+        deduped = []
+
+        for endpoint in endpoints:
+            url = endpoint.get('url')
+            if url and url not in seen_urls:
+                seen_urls.add(url)
+                deduped.append(endpoint)
+
+        return deduped
 
     def _prometheus_endpoints_with_tls(self) -> List[Dict[str, Any]]:
         """Add TLS information to Prometheus endpoints.
@@ -720,7 +731,10 @@ class GrafanaAgentCharm(CharmBase):
                 }
             prometheus_endpoints.append(prometheus_endpoint)
 
-        return self._enhance_endpoints_with_tls(prometheus_endpoints)
+        # Deduplicate endpoints to prevent crashes in grafana-agent
+        deduped_endpoints = self._deduplicate_endpoints(prometheus_endpoints)
+
+        return self._enhance_endpoints_with_tls(deduped_endpoints)
 
     def _loki_endpoints_with_tls(self) -> List[Dict[str, Any]]:
         """Add TLS information to Loki endpoints.
@@ -1092,12 +1106,12 @@ class GrafanaAgentCharm(CharmBase):
             for config in configs:
                 for scrape_config in config.get("scrape_configs", []):
                     if scrape_config.get("loki_push_api"):
-                        scrape_config["loki_push_api"]["server"][
-                            "http_tls_config"
-                        ] = self.tls_config
-                        scrape_config["loki_push_api"]["server"][
-                            "grpc_tls_config"
-                        ] = self.tls_config
+                        scrape_config["loki_push_api"]["server"]["http_tls_config"] = (
+                            self.tls_config
+                        )
+                        scrape_config["loki_push_api"]["server"]["grpc_tls_config"] = (
+                            self.tls_config
+                        )
 
         configs.extend(self._additional_log_configs)  # type: ignore
         return (

--- a/tests/unit/test_endpoint_deduplication.py
+++ b/tests/unit/test_endpoint_deduplication.py
@@ -1,0 +1,57 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+
+import yaml
+from ops.testing import Container, Context, Relation, State
+
+from charm import GrafanaAgentK8sCharm
+from grafana_agent import CONFIG_PATH
+
+
+def test_prometheus_endpoints_deduplication():
+    # GIVEN a set of duplicate Prometheus endpoints
+    REMOTE_WRITE_URL = "http://traefik.ip/cos-mimir/api/v1/push"
+    mimir_relation = Relation(
+        "send-remote-write",
+        remote_units_data={
+            0: {"remote_write": json.dumps({"url": REMOTE_WRITE_URL})},
+            1: {"remote_write": json.dumps({"url": REMOTE_WRITE_URL})},
+            2: {"remote_write": json.dumps({"url": REMOTE_WRITE_URL})},
+        },
+    )
+    state = State(
+        leader=True,
+        containers={Container(name="agent", can_connect=True)},
+        relations=[
+            mimir_relation,
+        ],
+        config={
+            "forward_alert_rules": True,
+        },
+    )
+
+    # WHEN the charm processes endpoints with duplicates
+    ctx = Context(charm_type=GrafanaAgentK8sCharm)
+
+    with ctx(ctx.on.config_changed(), state) as mgr:
+        output_state = mgr.run()
+        agent = output_state.get_container("agent")
+
+        # THEN the agent has started
+        assert agent.services["agent"].is_running()
+        # AND the grafana agent config has deduplicated the endpoints
+        fs = agent.get_filesystem(ctx)
+        gagent_config = fs.joinpath(*CONFIG_PATH.strip("/").split("/"))
+        assert gagent_config.exists()
+        yml = yaml.safe_load(gagent_config.read_text())
+        # check endpoints are deduplicated in the metrics section
+        metrics_config = yml["metrics"]["configs"][0]
+        assert metrics_config["name"] == "agent_scraper"
+        assert len(metrics_config["remote_write"]) == 1
+        assert metrics_config["remote_write"][0]["url"] == REMOTE_WRITE_URL
+        # check endpoints are deduplicated in the integrations section
+        integrations_config = yml["integrations"]
+        assert len(integrations_config["prometheus_remote_write"]) == 1
+        assert integrations_config["prometheus_remote_write"][0]["url"] == REMOTE_WRITE_URL


### PR DESCRIPTION
## Issue
Addresses #382 for track **1**.


## Solution
Addresses in the `remote_write` sections are now deduplicated to avoid crashes.


## Context
This has been discovered and addressed in the context of PC testing. Note that this only affects remote_write sections of the config, so Loki and Tempo are unaffected.


## Testing Instructions
Review the PR and run the unit test, or: manually try to deploy the charm with a scaled-up Mimir coordinator that's using Traefik.
