### PR TITLE
fix: delete CA cert on receive-ca-cert relation removed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -208,6 +208,20 @@ class GrafanaAgentK8sCharm(GrafanaAgentCharm):
         version_output, _ = self._container.exec(["/bin/agent", "-version"]).wait_output()
         return version_output
 
+    def list_files(self, path: str):
+        """Get a list of all files (and directories) at a path.
+
+        This method relies on the `Container.list_files()` method which accepts a path as string and returns a list of directory entries as pebble.FileInfo
+        Ref: https://github.com/canonical/operator/blob/ed173824fad4fbf2236120a263b0882feda413db/ops/model.py#L2894
+        We'll iterative over the found pebble.FileInfo paths and return the string path of each using pebble.FileInfo.path
+
+        Returns:
+            List of paths as string
+        """
+        paths = self._container.list_files(path)
+        logger.info("Paths are: %s", paths)
+        return [path.path for path in paths]
+
     def read_file(self, filepath: Union[str, pathlib.Path]):
         """Read a file's contents.
 

--- a/src/grafana_agent.py
+++ b/src/grafana_agent.py
@@ -465,8 +465,8 @@ class GrafanaAgentCharm(CharmBase):
     def _on_cert_transfer_removed(self, event: CertificatesRemovedEvent):
         certs_to_remove = [
             filename
-            for filename in os.listdir(self._ca_folder_path)
-            if filename.startswith(f"receive-ca-cert-{self.model.uuid}-{event.relation_id}")
+            for filename in self.list_files(self._ca_folder_path)
+            if f"receive-ca-cert-{self.model.uuid}-{event.relation_id}" in filename
         ]
         for cert in certs_to_remove:
             self.delete_file(cert)
@@ -482,6 +482,14 @@ class GrafanaAgentCharm(CharmBase):
     def is_ready(self):
         """Checks if the charm is ready for configuration."""
         raise NotImplementedError("Please override the is_ready method")
+
+    def list_files(self, path: str):
+        """Get the list of all paths and dirs at path.
+
+        Returns:
+            List of paths of files and dirs at dir path
+        """
+        raise NotImplementedError("Please override the list_files method")
 
     def read_file(self, filepath: Union[str, Path]):
         """Read a file's contents.


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This PR fixes #410.
Currently, the charm attempts to delete the CA cert from the charm container, but that is wrong as the CA cert is saved to the workload (`agent`) container. 
## Solution
<!-- A summary of the solution addressing the above issue -->
The changes are:
- Adds a `list_files` method which returns the list of files at a destination.
- We call that method and pass the path to the store for CA certs (`/usr/local/share/ca-certificates`) and delete the relevant CA certs.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
