### PR TITLE
feat(terraform): add channel validation and split outputs

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -38,5 +38,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
-| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,9 +2,16 @@ output "app_name" {
   value = juju_application.grafana_agent.name
 }
 
-output "endpoints" {
+output "provides" {
   value = {
-    # Requires
+    tracing_provider            = "tracing-provider",
+    logging_provider            = "logging-provider",
+    grafana_dashboards_provider = "grafana-dashboards-provider",
+  }
+}
+
+output "requires" {
+  value = {
     certificates                = "certificates",
     send_remote_write           = "send-remote-write",
     metrics_endpoint            = "metrics-endpoint",
@@ -13,9 +20,5 @@ output "endpoints" {
     grafana_cloud_config        = "grafana-cloud-config",
     receive_ca_cert             = "receive-ca-cert",
     tracing                     = "tracing",
-    # Provides
-    tracing_provider            = "tracing-provider",
-    logging_provider            = "logging-provider",
-    grafana_dashboards_provider = "grafana-dashboards-provider",
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {


### PR DESCRIPTION
Add validation to the  variable in Terraform modules to ensure the  track is used.

Split the  output into separate  and  outputs.

See canonical/alertmanager-k8s-operator#403 and canonical/alertmanager-k8s-operator#396 for reference.